### PR TITLE
add dockerfile which builds a cinny container served by nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+## Builder
+FROM node:14-alpine as builder
+
+WORKDIR /src
+
+COPY . /src
+RUN npm install \
+  && npm run build
+
+
+## App
+FROM nginx:alpine
+
+COPY --from=builder /src/dist /app
+COPY --from=builder /src/olm.wasm /app/olm.wasm
+
+# Insert wasm type into Nginx mime.types file so they load correctly.
+RUN sed -i '3i\ \ \ \ application/wasm wasm\;' /etc/nginx/mime.types
+
+RUN rm -rf /usr/share/nginx/html \
+  && ln -s /app /usr/share/nginx/html


### PR DESCRIPTION
# Description
This PR adds a Dockerfile, which builds the current Cinny code in two steps:
1. build phase builds the code using the production configs in a node14-alpine container
2. run phase copies the statically built files to an nginx container to be served on port 80

This should hopefully make it simple for folks to build and deploy a containerized version of this app easily!

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)