### PR TITLE
Remove username login requirements and sanitise out leading "@"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Organized and powerful matrix client.",
   "main": "index.js",
   "engines": {
-    "npm": "6.14.11",
-    "node": "14.6.0"
+    "npm": ">=6.14.11",
+    "node": ">=14.6.0"
   },
   "scripts": {
     "start": "webpack serve --config ./webpack.dev.js --open",

--- a/src/app/templates/auth/Auth.jsx
+++ b/src/app/templates/auth/Auth.jsx
@@ -13,8 +13,12 @@ import Spinner from '../../atoms/spinner/Spinner';
 
 import CinnySvg from '../../../../public/res/svg/cinny.svg';
 
-const USERNAME_REGEX = /^[a-z0-9_-]+$/;
-const BAD_USERNAME_ERROR = 'Username must contain only lowercase letters, numbers, dashes and underscores.';
+// This regex validates historical usernames, which don't satisy today's username requirements.
+// See https://matrix.org/docs/spec/appendices#id13 for more info.
+const LOCALPART_LOGIN_REGEX = /^[!-9|;-~]+$/;
+const LOCALPART_SIGNUP_REGEX = /^[a-z0-9_\-+./]+$/;
+const BAD_LOCALPART_ERROR = 'Username must contain only lowercase letters, numbers, dashes and underscores.';
+const USER_ID_TOO_LONG_ERROR = 'Your user ID, including the hostname, can\'t be more than 255 characters long.';
 
 const PASSWORD_REGEX = /.+/;
 const PASSWORD_STRENGHT_REGEX = /^(?=.*\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[^\w\d\s:])([^\s]){8,16}$/;
@@ -50,6 +54,18 @@ function validateOnChange(e, regex, error) {
   e.target.style.removeProperty('border');
   e.target.style.removeProperty('box-shadow');
   document.getElementById('auth_submit-btn').disabled = false;
+}
+
+/**
+ * Normalizes a username into a standard format.
+ *
+ * Removes leading and trailing whitespaces and leading "@" symbols.
+ * @param {string} rawUsername A raw-input username, which may include invalid characters.
+ * @returns {string}
+ */
+function normalizeUsername(rawUsername) {
+  const noLeadingAt = rawUsername.indexOf('@') === 0 ? rawUsername.substr(1) : rawUsername;
+  return noLeadingAt.trim();
 }
 
 function Auth({ type }) {
@@ -99,12 +115,17 @@ function Auth({ type }) {
     document.getElementById('auth_submit-btn').disabled = true;
     document.getElementById('auth_error').style.display = 'none';
 
-    if (!isValidInput(usernameRef.current.value, USERNAME_REGEX)) {
-      showBadInputError(usernameRef.current, BAD_USERNAME_ERROR);
+    /** @type {string} */
+    const rawUsername = usernameRef.current.value;
+    /** @type {string} */
+    const normalizedUsername = normalizeUsername(rawUsername);
+
+    if (!isValidInput(normalizedUsername, LOCALPART_LOGIN_REGEX)) {
+      showBadInputError(usernameRef.current, BAD_LOCALPART_ERROR);
       return;
     }
 
-    auth.login(usernameRef.current.value, homeserverRef.current.value, passwordRef.current.value)
+    auth.login(normalizedUsername, homeserverRef.current.value, passwordRef.current.value)
       .then(() => {
         document.getElementById('auth_submit-btn').disabled = false;
         window.location.replace('/');
@@ -122,8 +143,8 @@ function Auth({ type }) {
     document.getElementById('auth_submit-btn').disabled = true;
     document.getElementById('auth_error').style.display = 'none';
 
-    if (!isValidInput(usernameRef.current.value, USERNAME_REGEX)) {
-      showBadInputError(usernameRef.current, BAD_USERNAME_ERROR);
+    if (!isValidInput(usernameRef.current.value, LOCALPART_SIGNUP_REGEX)) {
+      showBadInputError(usernameRef.current, BAD_LOCALPART_ERROR);
       return;
     }
     if (!isValidInput(passwordRef.current.value, PASSWORD_STRENGHT_REGEX)) {
@@ -136,6 +157,10 @@ function Auth({ type }) {
     }
     if (!isValidInput(emailRef.current.value, EMAIL_REGEX)) {
       showBadInputError(emailRef.current, BAD_EMAIL_ERROR);
+      return;
+    }
+    if (`@${usernameRef.current.value}:${homeserverRef.current.value}`.length > 255) {
+      showBadInputError(usernameRef.current, USER_ID_TOO_LONG_ERROR);
       return;
     }
     register();
@@ -171,7 +196,9 @@ function Auth({ type }) {
             <div className="username__wrapper">
               <Input
                 forwardRef={usernameRef}
-                onChange={(e) => validateOnChange(e, USERNAME_REGEX, BAD_USERNAME_ERROR)}
+                onChange={(e) => (type === 'login'
+                  ? validateOnChange(e, LOCALPART_LOGIN_REGEX, BAD_LOCALPART_ERROR)
+                  : validateOnChange(e, LOCALPART_SIGNUP_REGEX, BAD_LOCALPART_ERROR))}
                 id="auth_username"
                 label="Username"
                 required


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

# Description

Matrix usernames generally _appear_ to start with "@", as in "**@phildenhoff**:matrix.org". I tend to assume that I sign in using the "@" symbol, so I've added a quick normalizer which removes that character from the localpart. However, at the same time, @Half-Shot asked that historical usernames be accepted, so I set up login to accept these older names (using the [Matrix spec](https://matrix.org/docs/spec/appendices#id13) and an ASCII chart to convert the hex they gave into characters) and signup to only accept the [currently accepted characters](https://matrix.org/docs/spec/appendices#id12).

Also: the package.json was set up to _only_ accept Node 14.6 instead of 14.6 or better. I'm using Node 16, so I did a quick fix to change that as well.

Fixes #10

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings