### PR TITLE
Fix building instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ by simply copying these files to the webroot:
 
 Execute the following commands to compile the app from its source code:
 
-```
-npm install #installs all dependencies
-npm build #compiles the app into the dist/ directory
+```sh
+npm install # Installs all dependencies
+npm run build # Compiles the app into the dist/ directory
 ```
 
 You can then copy the files to a webserver's webroot of your choosing as noted above. 


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

# Description

Running `npm build` gives:
```sh
$ npm build
> Unknown command: "build"
> 
> Did you mean this?
>    npm run build # run the "build" package script
>
> To see a list of supported npm commands, run:
>  npm help
```

This PR fixes the following to the build instructions:

 * Add spaces between hashtag `#` and the text `#text` -> `# text`
 * Capitalized the first letter of each sentence in the code block `# blah` -> `# Blah`
 * Changed the code block language to `sh` *(Comments are now grey)*

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation fix *(I guess?)*

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings