### PR TITLE
Fix for invalid password bug on Synapse/Official Matrix Server?

### DIFF
--- a/src/client/action/auth.js
+++ b/src/client/action/auth.js
@@ -15,7 +15,10 @@ async function login(username, homeserver, password) {
   const client = sdk.createClient({ baseUrl });
 
   const response = await client.login('m.login.password', {
-    user: `@${username}:${homeserver}`,
+    identifier: {
+      type: 'm.id.user',
+      user: username,
+    },
     password,
     initial_device_display_name: cons.DEVICE_DISPLAY_NAME,
   });


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

# Description

There is a bug where it says Invalid Password on my Synapse server, so I compared the payload against Element and found that the payload is a little different on Element compared to Cinny, I however am unsure if this causes issues on Dendrite or other Matrix server implementations.

Essentially this could be either a simple bug fix or breaking change.

I've tested this on my self hosted Synapse server, and official/default Matrix server. I'm unsure about Dendrite but I doubt it'll cause issues due to it also working with Element fine.

# Fixes

Updated payload in src/client/action/auth.js to reflect the updated authentication payload that doesn't cause the invalid password message on Synapse servers.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings