### PR TITLE
Add 'events' to resolve.fallback to fix build

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -16,6 +16,7 @@ module.exports = {
       'stream': require.resolve('stream-browserify'),
       'util': require.resolve('util/'),
       'assert': require.resolve('assert/'),
+      'events': require.resolve('events/'),
     }
   },
   node: {


### PR DESCRIPTION
This fixed it on my end. Here's the error for reference: 

```
Module not found: Error: Can't resolve 'events' in 'C:\Users\freshgum\Development\cinny\src\app\molecules\import-e2e-room-keys'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "events": require.resolve("events/") }'
	- install 'events'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "events": false }
```

<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

### Description

It just broke the build locally for me. Adding this fixed it.
You told me to submit a PR; here it is :-)

#### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
