### PR TITLE
Custom homeserver url support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 ## Builder
 FROM node:14-alpine as builder
 
+ENV default_server=matrix.org
+
 WORKDIR /src
 
 COPY . /src
+
+RUN sed -i 's/value="matrix.org"/value="'$default_server'"/' /src/src/app/templates/auth/Auth.jsx
+
 RUN npm install \
   && npm run build
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ To serve a development version of the app locally for testing, you may also use 
 This repository includes a Dockerfile, which builds the application from source and serves it with Nginx on port 80. To
 use this locally, you can build the container like so:
 
+To set a custom homeserver url change the default_server variable in the Dockerfile.
+
 ```
 docker build -t cinny:latest .
 ```


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

### Description

This adds a easier way to change the default homeserver. A user would put their HS URL into the docker file and build the image. I wanted to make this run when the container was started however I couldn't find any resources online to do so.

#### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
