### PR TITLE
Disallow sending messages to rooms with insufficient powerlevel

### DIFF
--- a/src/app/organisms/room/RoomViewInput.jsx
+++ b/src/app/organisms/room/RoomViewInput.jsx
@@ -333,7 +333,7 @@ function RoomViewInput({
   function renderInputs() {
     if (!canISend) {
       return (
-        <p className="room-input__disallowed">You do not have permission to post to this room</p>
+        <Text className="room-input__disallowed">You do not have permission to post to this room</Text>
       );
     }
     return (

--- a/src/app/organisms/room/RoomViewInput.jsx
+++ b/src/app/organisms/room/RoomViewInput.jsx
@@ -327,7 +327,15 @@ function RoomViewInput({
     if (file !== null) roomsInput.setAttachment(roomId, file);
   }
 
+  const myPowerlevel = roomTimeline.room.getMember(mx.getUserId()).powerLevel;
+  const canISend = roomTimeline.room.currentState.hasSufficientPowerLevelFor('events_default', myPowerlevel);
+
   function renderInputs() {
+    if (!canISend) {
+      return (
+        <p className="room-input__disallowed">You do not have permission to post to this room</p>
+      );
+    }
     return (
       <>
         <div className={`room-input__option-container${attachment === null ? '' : ' room-attachment__option'}`}>

--- a/src/app/organisms/room/RoomViewInput.scss
+++ b/src/app/organisms/room/RoomViewInput.scss
@@ -4,7 +4,6 @@
   min-height: 48px;
 
   &__disallowed {
-    color: var(--tc-surface-low);
     flex: 1;
     text-align: center;
   }

--- a/src/app/organisms/room/RoomViewInput.scss
+++ b/src/app/organisms/room/RoomViewInput.scss
@@ -3,6 +3,12 @@
   display: flex;
   min-height: 48px;
 
+  &__disallowed {
+    color: var(--tc-surface-low);
+    flex: 1;
+    text-align: center;
+  }
+
   &__space {
     min-width: 0;
     align-self: center;


### PR DESCRIPTION
### Description
This checks the powerlevel of the user against the room `events_default` powerlevel setting. Please let me know if there's a better way to implement this.

![Screen Shot 2021-09-30 at 16 25 12](https://user-images.githubusercontent.com/6954968/135473983-0480302d-1715-4746-a209-dcabc32a6523.png)

Fixes #123

#### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
