### PR TITLE
Improve message when there are no public rooms on a server

### DIFF
--- a/src/app/organisms/public-rooms/PublicRooms.jsx
+++ b/src/app/organisms/public-rooms/PublicRooms.jsx
@@ -137,16 +137,22 @@ function PublicRooms({ isOpen, searchTerm, onRequestClose }) {
       updateNextBatch(result.next_batch);
       updateIsSearching(false);
       updateIsViewMore(false);
-      if (totalRooms.length === 0 && inputRoomName !== '') {
+      if (totalRooms.length === 0) {
         updateSearchQuery({
-          error: `No result found for "${inputRoomName}" on ${inputHs}`,
+          error: inputRoomName === ''
+            ? `No public rooms on ${inputHs}`
+            : `No result found for "${inputRoomName}" on ${inputHs}`,
           alias: isInputAlias ? inputRoomName : null,
         });
       }
     } catch (e) {
       updatePublicRooms([]);
+      let err = 'Something went wrong!';
+      if (e?.httpStatus >= 400 && e?.httpStatus < 500) {
+        err = e.message;
+      }
       updateSearchQuery({
-        error: 'Something went wrong!',
+        error: err,
         alias: isInputAlias ? inputRoomName : null,
       });
       updateIsSearching(false);
@@ -241,19 +247,11 @@ function PublicRooms({ isOpen, searchTerm, onRequestClose }) {
             )
           }
           {
-            typeof searchQuery.name !== 'undefined' && !isSearching && publicRooms.length !== 0 && (
+            typeof searchQuery.name !== 'undefined' && !isSearching && (
               searchQuery.name === ''
                 ? <Text variant="b2">{`Public rooms on ${searchQuery.homeserver}.`}</Text>
                 : <Text variant="b2">{`Search result for "${searchQuery.name}" on ${searchQuery.homeserver}.`}</Text>
             )
-          }
-          {
-             typeof searchQuery.name !== 'undefined' && !isSearching && publicRooms.length === 0
-              && (
-              <div className="flex--center">
-                <Text variant="b2">{`There are no public rooms on ${searchQuery.homeserver}.`}</Text>
-              </div>
-              )
           }
           { searchQuery.error && (
             <>

--- a/src/app/organisms/public-rooms/PublicRooms.jsx
+++ b/src/app/organisms/public-rooms/PublicRooms.jsx
@@ -137,7 +137,7 @@ function PublicRooms({ isOpen, searchTerm, onRequestClose }) {
       updateNextBatch(result.next_batch);
       updateIsSearching(false);
       updateIsViewMore(false);
-      if (totalRooms.length === 0) {
+      if (totalRooms.length === 0 && inputRoomName !== '') {
         updateSearchQuery({
           error: `No result found for "${inputRoomName}" on ${inputHs}`,
           alias: isInputAlias ? inputRoomName : null,
@@ -241,11 +241,19 @@ function PublicRooms({ isOpen, searchTerm, onRequestClose }) {
             )
           }
           {
-            typeof searchQuery.name !== 'undefined' && !isSearching && (
+            typeof searchQuery.name !== 'undefined' && !isSearching && publicRooms.length !== 0 && (
               searchQuery.name === ''
                 ? <Text variant="b2">{`Public rooms on ${searchQuery.homeserver}.`}</Text>
                 : <Text variant="b2">{`Search result for "${searchQuery.name}" on ${searchQuery.homeserver}.`}</Text>
             )
+          }
+          {
+             typeof searchQuery.name !== 'undefined' && !isSearching && publicRooms.length === 0
+              && (
+              <div className="flex--center">
+                <Text variant="b2">{`There are no public rooms on ${searchQuery.homeserver}.`}</Text>
+              </div>
+              )
           }
           { searchQuery.error && (
             <>


### PR DESCRIPTION
### Description

When the homeserver has no public or no published public rooms, Cinny would show an error message stating `No result found for "" on HS`. This PR changes the logic and adds a new text that says `No public rooms on HS.` when there are no or no published rooms on the HS.

Fixes #127

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
