### PR TITLE
Add support for SSO Login (#9)

### DIFF
--- a/src/app/molecules/sso-buttons/SSOButtons.jsx
+++ b/src/app/molecules/sso-buttons/SSOButtons.jsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import './SSOButtons.scss';
+
+import { createTemporaryClient, getLoginFlows, startSsoLogin } from '../../../client/action/auth';
+
+function SSOButtons({ homeserver }) {
+  const [identityProviders, setIdentityProviders] = useState([]);
+
+  useEffect(() => {
+    // If the homeserver passed in is not a fully-qualified domain name, do not update.
+    if (!homeserver.match('(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-).)+[a-zA-Z]{2,63}$)')) {
+      return;
+    }
+
+    // TODO Check that there is a Matrix server at homename before making requests.
+    // This will prevent the CORS errors that happen when a user changes their homeserver.
+    createTemporaryClient(homeserver).then((client) => {
+      const providers = [];
+      getLoginFlows(client).then((flows) => {
+        if (flows.flows !== undefined) {
+          const ssoFlows = flows.flows.filter((flow) => flow.type === 'm.login.sso' || flow.type === 'm.login.cas');
+          ssoFlows.forEach((flow) => {
+            if (flow.identity_providers !== undefined) {
+              const type = flow.type.substring(8);
+              flow.identity_providers.forEach((idp) => {
+                const imageSrc = client.mxcUrlToHttp(idp.icon);
+                providers.push({
+                  homeserver, id: idp.id, name: idp.name, type, imageSrc,
+                });
+              });
+            }
+          });
+        }
+        setIdentityProviders(providers);
+      }).catch(() => {});
+    }).catch(() => {
+      setIdentityProviders([]);
+    });
+  }, [homeserver]);
+
+  // TODO Render all non-icon providers at the end so that they are never inbetween icons.
+  return (
+    <div className="sso-buttons">
+      {identityProviders.map((idp) => {
+        if (idp.imageSrc == null || idp.imageSrc === undefined || idp.imageSrc === '') {
+          return (
+            <button
+              key={idp.id}
+              type="button"
+              onClick={() => { startSsoLogin(homeserver, idp.type, idp.id); }}
+              className="sso-buttons__fallback-text text-b1"
+            >
+              {`Log in with ${idp.name}`}
+            </button>
+          );
+        }
+        return (
+          <SSOButton
+            key={idp.id}
+            homeserver={idp.homeserver}
+            id={idp.id}
+            name={idp.name}
+            type={idp.type}
+            imageSrc={idp.imageSrc}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function SSOButton({
+  homeserver, id, name, type, imageSrc,
+}) {
+  function handleClick() {
+    startSsoLogin(homeserver, type, id);
+  }
+  return (
+    <button type="button" className="sso-button" onClick={handleClick}>
+      <img className="sso-button__img" src={imageSrc} alt={name} />
+    </button>
+  );
+}
+
+SSOButtons.propTypes = {
+  homeserver: PropTypes.string.isRequired,
+};
+
+SSOButton.propTypes = {
+  homeserver: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  imageSrc: PropTypes.string.isRequired,
+};
+
+export default SSOButtons;

--- a/src/app/molecules/sso-buttons/SSOButtons.scss
+++ b/src/app/molecules/sso-buttons/SSOButtons.scss
@@ -1,0 +1,31 @@
+.sso-buttons {
+  margin-top: var(--sp-extra-loose);
+
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+
+  &__fallback-text {
+    margin: var(--sp-tight) 0px;
+
+    flex-basis: 100%;
+    text-align: center;
+
+    color: var(--bg-primary);
+    cursor: pointer;
+  }
+}
+
+.sso-button {
+  margin-bottom: var(--sp-normal);
+
+  display: flex;
+  justify-content: center;
+  flex-basis: 20%;
+
+  cursor: pointer;
+
+  &__img {
+    height: var(--av-normal);
+  }
+}

--- a/src/app/templates/auth/Auth.jsx
+++ b/src/app/templates/auth/Auth.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import './Auth.scss';
 import ReCAPTCHA from 'react-google-recaptcha';
 
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import * as auth from '../../../client/action/auth';
+import cons from '../../../client/state/cons';
 
 import Text from '../../atoms/text/Text';
 import Button from '../../atoms/button/Button';
@@ -15,6 +16,7 @@ import ScrollView from '../../atoms/scroll/ScrollView';
 
 import EyeIC from '../../../../public/res/ic/outlined/eye.svg';
 import CinnySvg from '../../../../public/res/svg/cinny.svg';
+import SSOButtons from '../../molecules/sso-buttons/SSOButtons';
 
 // This regex validates historical usernames, which don't satisfy today's username requirements.
 // See https://matrix.org/docs/spec/appendices#id13 for more info.
@@ -73,11 +75,34 @@ function normalizeUsername(rawUsername) {
 
 function Auth({ type }) {
   const [process, changeProcess] = useState(null);
+  const [homeserver, changeHomeserver] = useState('matrix.org');
+
   const usernameRef = useRef(null);
   const homeserverRef = useRef(null);
   const passwordRef = useRef(null);
   const confirmPasswordRef = useRef(null);
   const emailRef = useRef(null);
+
+  const { search } = useLocation();
+  const searchParams = new URLSearchParams(search);
+  if (searchParams.has('loginToken')) {
+    const loginToken = searchParams.get('loginToken');
+    if (loginToken !== undefined) {
+      if (localStorage.getItem(cons.secretKey.BASE_URL) !== undefined) {
+        const baseUrl = localStorage.getItem(cons.secretKey.BASE_URL);
+        auth.loginWithToken(baseUrl, loginToken)
+          .then(() => {
+            window.location.replace('/');
+          })
+          .catch((error) => {
+            changeProcess(null);
+            if (!error.contains('CORS request rejected')) {
+              renderErrorMessage(error);
+            }
+          });
+      }
+    }
+  }
 
   function register(recaptchaValue, terms, verified) {
     auth.register(
@@ -203,6 +228,7 @@ function Auth({ type }) {
               />
               <Input
                 forwardRef={homeserverRef}
+                onChange={(e) => changeHomeserver(e.target.value)}
                 id="auth_homeserver"
                 placeholder="Homeserver"
                 value="matrix.org"
@@ -269,6 +295,9 @@ function Auth({ type }) {
                 {type === 'login' ? 'Login' : 'Register' }
               </Button>
             </div>
+            {type === 'login' && (
+              <SSOButtons homeserver={homeserver} />
+            )}
           </form>
         </div>
 


### PR DESCRIPTION
### Description
This pull request adds basic SSO login support. It is not a full implementation of User-Interactive Authentication API (which would require a redesign of the login page), but it does allow users to log in using the single sign-on providers that their homeservers offer. This will greatly expand the number of users that can use Cinny!

![image](https://user-images.githubusercontent.com/51384945/136714003-0caf7499-a6ed-4868-8f0b-46312d80fec7.png)
![image](https://user-images.githubusercontent.com/51384945/136714010-6f6680b5-006b-4523-b728-cbce34a7ace3.png)


One caveat of this current implementation is that it sends requests to all valid domain names that are typed in the homeserver input box. This results in CORS errors in the console, but functionality is not impacted. This is something that should probably be addressed using error handling or a save/edit button in the UI.

This code compiles with no errors or warnings, and as mentioned earlier, the CORS errors in console have no impact on functionality.

Fixes #9 

#### Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- (Unsure) My changes generate no new warnings
