### PR TITLE
Add bidi support

### DIFF
--- a/src/app/atoms/text/Text.scss
+++ b/src/app/atoms/text/Text.scss
@@ -39,3 +39,12 @@
   @include font(b3, 400);
   color: var(--tc-surface-low);
 }
+
+.text-h1, .text-h2,
+.text-s1,
+.text-b1, .text-b2, .text-b3,
+p {
+direction: ltr;
+unicode-bidi: plaintext;
+text-align: initial;
+}


### PR DESCRIPTION
### Description

Curentlly Cinny is not supporting RTL texts. With this style Cinny become compatible with both LTR and RTL texts.

I check it using `inspect` on my browser, becaus i can't build Cinny on my system.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
