### PR TITLE
Address 301 redirect issue and Safari regex issue.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,3 @@
 # Redirects from what the browser requests to what we serve
+/login       /
 /register    /

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,2 @@
 # Redirects from what the browser requests to what we serve
-/login       /
 /register    /

--- a/src/app/molecules/sso-buttons/SSOButtons.jsx
+++ b/src/app/molecules/sso-buttons/SSOButtons.jsx
@@ -9,7 +9,7 @@ function SSOButtons({ homeserver }) {
 
   useEffect(() => {
     // If the homeserver passed in is not a fully-qualified domain name, do not update.
-    if (!homeserver.match('(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-).)+[a-zA-Z]{2,63}$)')) {
+    if (!homeserver.match('^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9](?:\\.[a-zA-Z]{2,})+$')) {
       return;
     }
 


### PR DESCRIPTION
### Description

This pull request replaces the regex used to match domain names with a new expression that does not use lookbehinds. As a result, Safari browsers no longer crash upon opening Cinny. This pull request also removes /login from the Netlify _redirects config file. This should address a current issue that prevents users from logging in to their SSO accounts in production, even though SSO works fine on a local development server.

Fixes #141

#### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings