### PR TITLE
Fixed links splitting across line mid-word

### DIFF
--- a/src/app/molecules/message/Message.scss
+++ b/src/app/molecules/message/Message.scss
@@ -160,7 +160,7 @@
   }
 
   & a {
-    word-break: break-all;
+    word-break: break-word;
   }
   &-edited {
     color: var(--tc-surface-low);


### PR DESCRIPTION
### Description

`break-all` meant that links would split mid-word e.g. I observed `email` become `e\nmail`. `break-word` avoids this but also ensures long links still break before overflowing the line length.

`break-all`:

![image](https://user-images.githubusercontent.com/92009746/139046333-9b4f3656-8874-4314-b1a2-ddbbd530a423.png)

`break-word`:

![image](https://user-images.githubusercontent.com/92009746/139046691-eec42d76-6257-4b52-8ef1-481249dc9153.png)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

