### PR TITLE
Suggest all commands when using `/`

### DIFF
--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -163,26 +163,6 @@ FollowingMembers.propTypes = {
   viewEvent: PropTypes.shape({}).isRequired,
 };
 
-function getCmdActivationMessage(prefix) {
-  function genMessage(prime, secondary) {
-    return (
-      <>
-        <span>{prime}</span>
-        <span>{secondary}</span>
-      </>
-    );
-  }
-  const cmd = {
-    '/': () => genMessage('General command mode activated. ', 'Type command name for suggestions.'),
-    '>*': () => genMessage('Go-to command mode activated. ', 'Type space name for suggestions.'),
-    '>#': () => genMessage('Go-to command mode activated. ', 'Type room name for suggestions.'),
-    '>@': () => genMessage('Go-to command mode activated. ', 'Type people name for suggestions.'),
-    ':': () => genMessage('Emoji autofill command mode activated. ', 'Type emoji shortcut for suggestions.'),
-    '@': () => genMessage('Name autofill command mode activated. ', 'Type name for suggestions.'),
-  };
-  return cmd[prefix]?.();
-}
-
 function CmdItem({ onClick, children }) {
   return (
     <button className="cmd-item" onClick={onClick} type="button">
@@ -297,6 +277,26 @@ function RoomViewCmdBar({ roomId, roomTimeline, viewEvent }) {
     setCmd({ prefix: cmd?.prefix || cmdPrefix, suggestions, option: cmdOption });
   }
 
+  function getCmdActivationMessage(prefix) {
+    function genMessage(prime, secondary) {
+      return (
+        <>
+          <span>{prime}</span>
+          <span>{secondary}</span>
+        </>
+      );
+    }
+    const cmd = {
+      '/': () => getCmdSuggestions(cmd, fireCmd),
+      '>*': () => genMessage('Go-to command mode activated. ', 'Type space name for suggestions.'),
+      '>#': () => genMessage('Go-to command mode activated. ', 'Type room name for suggestions.'),
+      '>@': () => genMessage('Go-to command mode activated. ', 'Type people name for suggestions.'),
+      ':': () => genMessage('Emoji autofill command mode activated. ', 'Type emoji shortcut for suggestions.'),
+      '@': () => genMessage('Name autofill command mode activated. ', 'Type name for suggestions.'),
+    };
+    return cmd[prefix]?.();
+  }
+
   function processCmd(prefix, slug) {
     let searchTerm = slug;
     cmdOption = undefined;
@@ -340,7 +340,7 @@ function RoomViewCmdBar({ roomId, roomTimeline, viewEvent }) {
       });
     }
     const setupSearch = {
-      '/': () => asyncSearch.setup(commands, { keys: ['name'], isContain: true }),
+      '/': () => asyncSearch.setup(commands, { keys: ['name'], isContain: true, suggestAllOnEmpty: true }),
       '>*': () => asyncSearch.setup(getRooms([...roomList.spaces]), { keys: ['name'], limit: 20 }),
       '>#': () => asyncSearch.setup(getRooms([...roomList.rooms]), { keys: ['name'], limit: 20 }),
       '>@': () => asyncSearch.setup(getRooms([...roomList.directs]), { keys: ['name'], limit: 20 }),

--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -441,30 +441,33 @@ function RoomViewCmdBar({ roomId, roomTimeline, viewEvent }) {
     );
   }
 
+  const inSuggestionMode = cmd !== null;
+  const hasSuggestions = inSuggestionMode && (typeof cmd.suggestions === 'undefined' || cmd.suggestions?.length > 0);
+
   return (
     <div className="cmd-bar">
       <div className="cmd-bar__info">
-        {cmd === null && <CmdHelp />}
-        {cmd !== null && typeof cmd.suggestions === 'undefined' && <div className="cmd-bar__info-indicator" /> }
-        {cmd !== null && typeof cmd.suggestions !== 'undefined' && <Text variant="b3">TAB</Text>}
+        {!inSuggestionMode && <CmdHelp />}
+        {inSuggestionMode && !hasSuggestions && <div className="cmd-bar__info-indicator" /> }
+        {inSuggestionMode && hasSuggestions && <Text variant="b3">TAB</Text>}
       </div>
       <div className="cmd-bar__content">
-        {cmd === null && (
+        {!inSuggestionMode && (
           <FollowingMembers
             roomId={roomId}
             roomTimeline={roomTimeline}
             viewEvent={viewEvent}
           />
         )}
-        {cmd !== null && typeof cmd.suggestions === 'undefined' && <Text className="cmd-bar__content-help" variant="b2">{getCmdActivationMessage(cmd.prefix)}</Text>}
-        {cmd !== null && typeof cmd.suggestions !== 'undefined' && (
+        {inSuggestionMode && !hasSuggestions && <Text className="cmd-bar__content-help" variant="b2">{getCmdActivationMessage(cmd.prefix)}</Text>}
+        {inSuggestionMode && hasSuggestions && (
           <ScrollView horizontal vertical={false} invisible>
             <div className="cmd-bar__content__suggestions">{getCmdSuggestions(cmd, fireCmd)}</div>
           </ScrollView>
         )}
       </div>
       <div className="cmd-bar__more">
-        {cmd !== null && cmd.prefix === '/' && <ViewCmd />}
+        {inSuggestionMode && cmd.prefix === '/' && <ViewCmd />}
       </div>
     </div>
   );

--- a/src/app/organisms/room/RoomViewInput.jsx
+++ b/src/app/organisms/room/RoomViewInput.jsx
@@ -256,7 +256,6 @@ function RoomViewInput({
     cmdCursorPos = cursor;
     if (cmdSlug === '') {
       activateCmd(cmdPrefix);
-      return;
     }
     if (!isCmdActivated) activateCmd(cmdPrefix);
     requestAnimationFrame(() => {

--- a/src/util/AsyncSearch.js
+++ b/src/util/AsyncSearch.js
@@ -16,6 +16,7 @@ class AsyncSearch extends EventEmitter {
     this.isContain = false;
     this.isCaseSensitive = false;
     this.ignoreWhitespace = true;
+    this.suggestAllOnEmpty = false;
     this.limit = null;
     this.findingList = [];
 
@@ -40,6 +41,7 @@ class AsyncSearch extends EventEmitter {
    * @param {boolean} [opts.isContain=false] - Add finding to result if it contain search term
    * @param {boolean} [opts.isCaseSensitive=false]
    * @param {boolean} [opts.ignoreWhitespace=true]
+   * @param {boolean} [opts.suggestAllOnEmpty=false]
    * @param {number} [opts.limit=null] - Stop search after limit
    */
   setup(dataList, opts) {
@@ -49,6 +51,7 @@ class AsyncSearch extends EventEmitter {
     this.isContain = opts?.isContain || false;
     this.isCaseSensitive = opts?.isCaseSensitive || false;
     this.ignoreWhitespace = opts?.ignoreWhitespace || true;
+    this.suggestAllOnEmpty = opts?.suggestAllOnEmpty || false;
     this.limit = opts?.limit || null;
   }
 
@@ -57,7 +60,7 @@ class AsyncSearch extends EventEmitter {
 
     this.term = (this.isCaseSensitive) ? term : term.toLocaleLowerCase();
     if (this.ignoreWhitespace) this.term = this.term.replace(' ', '');
-    if (this.term === '') {
+    if (this.term === '' && !this.suggestAllOnEmpty) {
       this._sendFindings();
       return;
     }


### PR DESCRIPTION
### Description

This implements a suggestion, that I am in agreement with. Knowing which
commands exists when first using Cinny is cumbersome, as completion
requires at least one letter to be used. I had to poke at arbitrary
letters to see if I was missing any commands at first.

By always suggesting all commands initially it removes the awkwardness
of discovery. At the cost of losing the activation message.

Fixes #157.

**Note**: I'm not sure the code is entirely *correct*. It works, it works as it should. But I'm not sure whether I'm missing some use cases from asyncSearch, or if I'm somewhat misusing event emission.

I'm also unsure whether this is desirable by the project. But eh, this was made mainly because I was playing around in this area and it helped me better understand how this works.

#### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
