### PR TITLE
Add basic support for displaying emotes

### DIFF
--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -106,10 +106,17 @@ MessageReply.propTypes = {
   content: PropTypes.string.isRequired,
 };
 
-function MessageContent({ content, isMarkdown, isEdited }) {
+function MessageContent({
+  senderName,
+  content,
+  isMarkdown,
+  isEdited,
+  msgType,
+}) {
   return (
     <div className="message__content">
       <div className="text text-b1">
+        { msgType === 'm.emote' && `* ${senderName} ` }
         { isMarkdown ? genMarkdown(content) : linkifyContent(content) }
       </div>
       { isEdited && <Text className="message__content-edited" variant="b3">(edited)</Text>}
@@ -121,9 +128,11 @@ MessageContent.defaultProps = {
   isEdited: false,
 };
 MessageContent.propTypes = {
+  senderName: PropTypes.string.isRequired,
   content: PropTypes.node.isRequired,
   isMarkdown: PropTypes.bool,
   isEdited: PropTypes.bool,
+  msgType: PropTypes.string.isRequired,
 };
 
 function MessageEdit({ content, onSave, onCancel }) {
@@ -228,10 +237,27 @@ MessageOptions.propTypes = {
 
 function Message({
   avatar, header, reply, content, editContent, reactions, options,
+  msgType,
 }) {
-  const msgClass = header === null ? ' message--content-only' : ' message--full';
+  const className = [
+    'message',
+    header === null ? ' message--content-only' : ' message--full',
+  ];
+  switch (msgType) {
+    case 'm.text':
+      className.push('message--type-text');
+      break;
+    case 'm.emote':
+      className.push('message--type-emote');
+      break;
+    case 'm.notice':
+      className.push('message--type-notice');
+      break;
+    default:
+  }
+
   return (
-    <div className={`message${msgClass}`}>
+    <div className={className.join(' ')}>
       <div className="message__avatar-container">
         {avatar !== null && avatar}
       </div>
@@ -254,6 +280,7 @@ Message.defaultProps = {
   editContent: null,
   reactions: null,
   options: null,
+  msgType: 'm.text',
 };
 Message.propTypes = {
   avatar: PropTypes.node,
@@ -263,6 +290,7 @@ Message.propTypes = {
   editContent: PropTypes.node,
   reactions: PropTypes.node,
   options: PropTypes.node,
+  msgType: PropTypes.string,
 };
 
 export {

--- a/src/app/molecules/message/Message.scss
+++ b/src/app/molecules/message/Message.scss
@@ -410,3 +410,14 @@
     }
   }
 }
+
+.message.message--type-emote {
+  .message__content {
+    font-style: italic;
+
+    // Remove blockness of first `<p>` so that markdown emotes stay on one line.
+    p:first-of-type {
+      display: inline;
+    }
+  }
+}

--- a/src/app/organisms/room/RoomViewContent.jsx
+++ b/src/app/organisms/room/RoomViewContent.jsx
@@ -282,6 +282,7 @@ function RoomViewContent({
 
     let content = mEvent.getContent().body;
     if (typeof content === 'undefined') return null;
+    const msgType = mEvent.getContent()?.msgtype;
     let reply = null;
     let reactions = null;
     let isMarkdown = mEvent.getContent().format === 'org.matrix.custom.html';
@@ -379,8 +380,10 @@ function RoomViewContent({
     );
     const userContent = (
       <MessageContent
+        senderName={getUsernameOfRoomMember(mEvent.sender)}
         isMarkdown={isMarkdown}
         content={isMedia(mEvent) ? genMediaContent(mEvent) : content}
+        msgType={msgType}
         isEdited={isEdited}
       />
     );
@@ -496,6 +499,7 @@ function RoomViewContent({
         header={userHeader}
         reply={userReply}
         content={editEvent !== null && isEditingEvent ? null : userContent}
+        msgType={msgType}
         editContent={editEvent !== null && isEditingEvent ? (
           <MessageEdit
             content={content}


### PR DESCRIPTION
### Description

This only handles *displaying* emote events in a specific manner
recognizable as an emote.

It requires passing the sender name to message content elements, so that
the name can be in-lined into the message.

Sending emotes requires more changes. Namely better support for
commands. It would be required that they're not tied to the
completion framework for activation, but hooked on message being
sent and starting with a `/`. (WIP elsewhere)


**Note**: Not to be confused with "custom emoticons" from #83.

#### Testing

You will need a client that can send emotes (e.g. `/me`) commands.

I was using Element at first, but continued by dogfooding the WIP feature in Cinny.

#### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
