### PR TITLE
Removed mixin that was wiping out existing padding

### DIFF
--- a/src/app/molecules/message/Message.scss
+++ b/src/app/molecules/message/Message.scss
@@ -370,7 +370,6 @@
   & blockquote {
     display: inline-block;
     max-width: 100%;
-    @include dir.side(padding, var(--sp-extra-tight), 0);
     @include dir.side(border, 4px solid var(--bg-surface-active), 0);
     white-space: initial !important;
 


### PR DESCRIPTION
# Problem
![quote-padding](https://user-images.githubusercontent.com/92009746/146720780-a47d33a8-ca3f-45d7-a998-a6c9b82fc2c7.png)

# Solution
![quote-padding-restored](https://user-images.githubusercontent.com/92009746/146721907-4e011325-0147-45ad-8a20-50ad146cb286.png)

# Details

[Line 335][] already gives blockquotes their padding. The [offending line][] explicitly sets the right padding back to 0 and the left padding to exactly what it was already set to.

It occurs to me that setting the left padding explicitly just for blockquotes, even though it already inherits this from a broader rule, might be intentional; In which case this fix is too simple. I'm not really familiar with the big picture on cinny's stylesheets, so feel free to use this as a prompt instead of a solution.

[Line 335]: https://github.com/ajbura/cinny/blob/ce9f140ddfbb675bc79b03e512a21feba602b1de/src/app/molecules/message/Message.scss#L335
[offending line]: https://github.com/ajbura/cinny/blob/ce9f140ddfbb675bc79b03e512a21feba602b1de/src/app/molecules/message/Message.scss#L373

<!-- Replace -->
Preview: https://61c026d5e151dc20cd658ddd--pr-cinny.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
