### PR TITLE
[Feature] Add support for sending user emoji using autocomplete

### DIFF
--- a/src/app/organisms/emoji-board/custom-emoji.js
+++ b/src/app/organisms/emoji-board/custom-emoji.js
@@ -1,0 +1,40 @@
+import { emojis } from './emoji';
+
+// Custom emoji are stored in one of three places:
+// - User emojis, which are stored in account data
+// - Room emojis, which are stored in state events in a room
+// - Emoji packs, which are rooms of emojis referenced in the account data or in a room's
+//   cannonical space
+//
+// Emojis and packs referenced from within a user's account data should be available
+// globally, while emojis and packs in rooms and spaces should only be available within
+// those spaces and rooms
+
+// Retrieve a list of user emojis
+//
+// Result is a list of objects, each with a shortcode and an mxc property
+//
+// Accepts a reference to a matrix client as the only argument
+function getUserEmoji(mx) {
+  const accountDataEmoji = mx.getAccountData('im.ponies.user_emotes');
+  const { images } = accountDataEmoji.event.content;
+  const mapped = Object.entries(images).map((e) => ({
+    shortcode: e[0],
+    mxc: e[1].url,
+  }));
+  return mapped;
+}
+
+// Returns all user emojis and all standard unicode emojis
+//
+// Accepts a reference to a matrix client as the only argument
+//
+// Will eventually be expanded to include all emojis revelant to a room and the user
+function getAllEmoji(mx) {
+  const userEmoji = getUserEmoji(mx);
+  const allEmojis = emojis.concat(userEmoji);
+
+  return allEmojis;
+}
+
+export { getUserEmoji, getAllEmoji };

--- a/src/app/organisms/emoji-board/custom-emoji.js
+++ b/src/app/organisms/emoji-board/custom-emoji.js
@@ -41,7 +41,7 @@ function getShortcodeToEmoji(mx) {
   const allEmoji = new Map();
 
   emojis.forEach((emoji) => {
-    if(emoji.shortcodes.constructor.name === "Array") {
+    if (emoji.shortcodes.constructor.name === 'Array') {
       emoji.shortcodes.forEach((shortcode) => {
         allEmoji.set(shortcode, emoji);
       });

--- a/src/app/organisms/emoji-board/custom-emoji.js
+++ b/src/app/organisms/emoji-board/custom-emoji.js
@@ -33,12 +33,42 @@ function getUserEmoji(mx) {
 //
 // Accepts a reference to a matrix client as the only argument
 //
+// Result is a map from shortcode to the corresponding emoji.  If two emoji share a
+// shortcode, only one will be presented, with priority given to custom emoji.
+//
 // Will eventually be expanded to include all emojis revelant to a room and the user
 function getAllEmoji(mx) {
-  const userEmoji = getUserEmoji(mx);
-  const allEmojis = emojis.concat(userEmoji);
+  const allEmoji = new Map();
 
-  return allEmojis;
+  for (let i = 0; i < emojis.length; i += 1) {
+    const emoji = emojis[i];
+    for (let j = 0; j < emoji.shortcodes; j += 1) {
+      allEmoji.set(emoji.shortcodes[j], emoji);
+    }
+  }
+
+  getUserEmoji(mx).forEach((emoji) => {
+    allEmoji.set(emoji.shortcode, emoji);
+  });
+
+  return allEmoji;
 }
 
-export { getUserEmoji, getAllEmoji };
+// Produces a special list of emoji specifically for auto-completion
+//
+// This list contains each emoji once, with all emoji being deduplicated by shortcode.
+// However, the order of the standard emoji will have been preserved, and alternate
+// shortcodes for the standard emoji will not be considered.
+//
+// Standard emoji are guaranteed to be earlier in the list than custom emoji
+function getEmojiForCompletion(mx) {
+  const allEmoji = new Map();
+  getUserEmoji(mx).forEach((emoji) => {
+    allEmoji.set(emoji.shortcode, emoji);
+  });
+
+  return emojis.filter((e) => !allEmoji.has(e.shortcode))
+    .concat(Array.from(allEmoji.values()));
+}
+
+export { getUserEmoji, getAllEmoji, getEmojiForCompletion };

--- a/src/app/organisms/emoji-board/custom-emoji.js
+++ b/src/app/organisms/emoji-board/custom-emoji.js
@@ -37,15 +37,18 @@ function getUserEmoji(mx) {
 // shortcode, only one will be presented, with priority given to custom emoji.
 //
 // Will eventually be expanded to include all emojis revelant to a room and the user
-function getAllEmoji(mx) {
+function getShortcodeToEmoji(mx) {
   const allEmoji = new Map();
 
-  for (let i = 0; i < emojis.length; i += 1) {
-    const emoji = emojis[i];
-    for (let j = 0; j < emoji.shortcodes; j += 1) {
-      allEmoji.set(emoji.shortcodes[j], emoji);
+  emojis.forEach((emoji) => {
+    if(emoji.shortcodes.constructor.name === "Array") {
+      emoji.shortcodes.forEach((shortcode) => {
+        allEmoji.set(shortcode, emoji);
+      });
+    } else {
+      allEmoji.set(emoji.shortcodes, emoji);
     }
-  }
+  });
 
   getUserEmoji(mx).forEach((emoji) => {
     allEmoji.set(emoji.shortcode, emoji);
@@ -71,4 +74,4 @@ function getEmojiForCompletion(mx) {
     .concat(Array.from(allEmoji.values()));
 }
 
-export { getUserEmoji, getAllEmoji, getEmojiForCompletion };
+export { getUserEmoji, getShortcodeToEmoji, getEmojiForCompletion };

--- a/src/app/organisms/emoji-board/custom-emoji.js
+++ b/src/app/organisms/emoji-board/custom-emoji.js
@@ -17,6 +17,10 @@ import { emojis } from './emoji';
 // Accepts a reference to a matrix client as the only argument
 function getUserEmoji(mx) {
   const accountDataEmoji = mx.getAccountData('im.ponies.user_emotes');
+  if (!accountDataEmoji) {
+    return [];
+  }
+
   const { images } = accountDataEmoji.event.content;
   const mapped = Object.entries(images).map((e) => ({
     shortcode: e[0],

--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -13,7 +13,7 @@ import {
   openPublicRooms,
   openInviteUser,
 } from '../../../client/action/navigation';
-import { getAllEmoji } from '../emoji-board/custom-emoji';
+import { getEmojiForCompletion } from '../emoji-board/custom-emoji';
 import AsyncSearch from '../../../util/AsyncSearch';
 
 import Text from '../../atoms/text/Text';
@@ -210,7 +210,7 @@ function RoomViewCmdBar({ roomId, roomTimeline, viewEvent }) {
         setCmd({ prefix, suggestions: commands });
       },
       ':': () => {
-        const emojis = getAllEmoji(mx);
+        const emojis = getEmojiForCompletion(mx);
         asyncSearch.setup(emojis, { keys: ['shortcode'], isContain: true, limit: 20 });
         setCmd({ prefix, suggestions: emojis.slice(26, 46) });
       },

--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -99,7 +99,12 @@ function renderSuggestions({ prefix, option, suggestions }, fireCmd) {
     // Render a custom emoji
     function renderCustomEmoji(emoji) {
       return (
-        <img className="emoji" src={mx.mxcUrlToHttp(emoji.mxc)} alt={`${mx.shortcocde} emoji`} />
+        <img
+          className="emoji"
+          src={mx.mxcUrlToHttp(emoji.mxc)}
+          data-mx-emoticon=""
+          alt={`:${mx.shortcode}:`}
+        />
       );
     }
 

--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -103,7 +103,7 @@ function renderSuggestions({ prefix, option, suggestions }, fireCmd) {
           className="emoji"
           src={mx.mxcUrlToHttp(emoji.mxc)}
           data-mx-emoticon=""
-          alt={`:${mx.shortcode}:`}
+          alt={`:${emoji.shortcode}:`}
         />
       );
     }

--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -13,7 +13,7 @@ import {
   openPublicRooms,
   openInviteUser,
 } from '../../../client/action/navigation';
-import { emojis } from '../emoji-board/emoji';
+import { getAllEmoji } from '../emoji-board/custom-emoji';
 import AsyncSearch from '../../../util/AsyncSearch';
 
 import Text from '../../atoms/text/Text';
@@ -81,24 +81,46 @@ function renderSuggestions({ prefix, option, suggestions }, fireCmd) {
   }
 
   function renderEmojiSuggestion(emPrefix, emos) {
+    const mx = initMatrix.matrixClient;
+
+    // Renders a small Twemoji
+    function renderTwemoji(emoji) {
+      return parse(twemoji.parse(
+        emoji.unicode,
+        {
+          attributes: () => ({
+            unicode: emoji.unicode,
+            shortcodes: emoji.shortcodes?.toString(),
+          }),
+        },
+      ));
+    }
+
+    // Render a custom emoji
+    function renderCustomEmoji(emoji) {
+      return (
+        <img className="emoji" src={mx.mxcUrlToHttp(emoji.mxc)} alt={`${mx.shortcocde} emoji`} />
+      );
+    }
+
+    // Dynamically render either a custom emoji or twemoji based on what the input is
+    function renderEmoji(emoji) {
+      if (emoji.mxc) {
+        return renderCustomEmoji(emoji);
+      }
+      return renderTwemoji(emoji);
+    }
+
     return emos.map((emoji) => (
       <CmdItem
-        key={emoji.hexcode}
+        key={emoji.shortcode}
         onClick={() => fireCmd({
           prefix: emPrefix,
           result: emoji,
         })}
       >
         {
-          parse(twemoji.parse(
-            emoji.unicode,
-            {
-              attributes: () => ({
-                unicode: emoji.unicode,
-                shortcodes: emoji.shortcodes?.toString(),
-              }),
-            },
-          ))
+          renderEmoji(emoji)
         }
         <Text variant="b2">{`:${emoji.shortcode}:`}</Text>
       </CmdItem>
@@ -183,6 +205,7 @@ function RoomViewCmdBar({ roomId, roomTimeline, viewEvent }) {
         setCmd({ prefix, suggestions: commands });
       },
       ':': () => {
+        const emojis = getAllEmoji(mx);
         asyncSearch.setup(emojis, { keys: ['shortcode'], isContain: true, limit: 20 });
         setCmd({ prefix, suggestions: emojis.slice(26, 46) });
       },
@@ -210,7 +233,7 @@ function RoomViewCmdBar({ roomId, roomTimeline, viewEvent }) {
     }
     if (myCmd.prefix === ':') {
       viewEvent.emit('cmd_fired', {
-        replace: myCmd.result.unicode,
+        replace: myCmd.result.mxc ? `:${myCmd.result.shortcode}: ` : myCmd.result.unicode,
       });
     }
     if (myCmd.prefix === '@') {

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -249,7 +249,7 @@ class RoomsInput extends EventEmitter {
         }:" height="32" vertical-align="middle" />`;
 
         content.formatted_body = content.formatted_body
-          .replace(`:${emoji.shortcode}:`, tag);
+          .replaceAll(`:${emoji.shortcode}:`, tag);
       }
 
       if (typeof input.replyTo !== 'undefined') {

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -2,7 +2,7 @@ import EventEmitter from 'events';
 import { micromark } from 'micromark';
 import { gfm, gfmHtml } from 'micromark-extension-gfm';
 import encrypt from 'browser-encrypt-attachment';
-import { getAllEmoji } from '../../app/organisms/emoji-board/custom-emoji';
+import { getShortcodeToEmoji } from '../../app/organisms/emoji-board/custom-emoji';
 import cons from './cons';
 import settings from './settings';
 
@@ -206,7 +206,7 @@ class RoomsInput extends EventEmitter {
   // This includes inserting any custom emoji that might be relevant, and (only if the
   // user has enabled it in their settings) formatting the message using markdown.
   formatAndEmojifyText(text) {
-    const allEmoji = getAllEmoji(this.matrixClient);
+    const allEmoji = getShortcodeToEmoji(this.matrixClient);
 
     // Check to see if there are any :shortcode-style-tags: in the message
     const shortcodes = Array.from(text.matchAll(/\B:([\w-]+):\B/g)).map((m) => m[1])

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -218,6 +218,8 @@ class RoomsInput extends EventEmitter {
     let formattedText;
     if (settings.isMarkdown) {
       formattedText = getFormattedBody(text);
+    } else {
+      formattedText = text;
     }
 
     // If there were any emojis, now we substitute :shortcodes: for the <img/> tag

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -206,7 +206,6 @@ class RoomsInput extends EventEmitter {
   // This includes inserting any custom emoji that might be relevant, and (only if the
   // user has enabled it in their settings) formatting the message using markdown.
   formatAndEmojifyText(text) {
-
     // Check to see if there are any :shortcode-style-tags: in the message
     const shortcodes = Array.from(text.matchAll(/\B:([\w-]+):\B/g)).map((m) => m[1]);
     // Find the corresponding emoji
@@ -216,8 +215,9 @@ class RoomsInput extends EventEmitter {
     // formatter
 
     // Now we apply markdown formatting
+    let formattedText;
     if (settings.isMarkdown) {
-      text = getFormattedBody(text);
+      formattedText = getFormattedBody(text);
     }
 
     // If there were any emojis, now we substitute :shortcodes: for the <img/> tag
@@ -229,12 +229,12 @@ class RoomsInput extends EventEmitter {
         emoji.shortcode
       }:" title=":${
         emoji.shortcode
-      }:" height="32" vertical-align="middle" />`;
+      }:" height="32" />`;
 
-      text = text.replaceAll(`:${emoji.shortcode}:`, tag);
+      formattedText = formattedText.replaceAll(`:${emoji.shortcode}:`, tag);
     }
 
-    return text;
+    return formattedText;
   }
 
   async sendInput(roomId) {
@@ -254,10 +254,10 @@ class RoomsInput extends EventEmitter {
 
       // Apply formatting if relevant
       const formattedBody = this.formatAndEmojifyText(input.message);
-      if(formattedBody != input.message) {
+      if (formattedBody !== input.message) {
         // Formatting was applied, and we need to switch to custom HTML
-          content.format = 'org.matrix.custom.html';
-          content.formatted_body = formattedBody;
+        content.format = 'org.matrix.custom.html';
+        content.formatted_body = formattedBody;
       }
 
       if (typeof input.replyTo !== 'undefined') {
@@ -390,7 +390,7 @@ class RoomsInput extends EventEmitter {
 
     // Apply formatting if relevant
     const formattedBody = this.formatAndEmojifyText(editedBody);
-    if(formattedBody != editedBody) {
+    if (formattedBody !== editedBody) {
       content.formatted_body = ` * ${formattedBody}`;
       content.format = 'org.matrix.custom.html';
       content['m.new_content'].formatted_body = formattedBody;

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -241,10 +241,9 @@ class RoomsInput extends EventEmitter {
         }
 
         // Splice the tag into the text
-        formattedText =
-          formattedText.substr(0, shortcodeMatch.index) +
-          tag +
-          formattedText.substr(shortcodeMatch.index + shortcodeMatch[0].length);
+        formattedText = formattedText.substr(0, shortcodeMatch.index)
+          + tag
+          + formattedText.substr(shortcodeMatch.index + shortcodeMatch[0].length);
       });
 
     return formattedText;


### PR DESCRIPTION
### Description

A *partial* implementation of #83

What's included:
- An implementation for detecting user emojis
- Addition of user emojis to the emoji autocomplete in the command bar
- Translation of shortcodes into image tags on message sending

What's not included:
- Loading emojis from the active room, loading the user's global emoji packs, loading emoji from spaces
- Selecting custom emoji using the emoji picker

I'm submitting this as a pull request as a sort of proof-of-concept of sending custom emojis.  As mentioned above, there's still more work to be done.  I'm hoping to use this as an opportunity to discuss architectural decisions (and also to make sure I haven't done anything stupid).

Once necessary revisions have been made, and if you decide that this code is good to go, I imagine that this could be merged, and additional features could be added with additional pull requests, to keep things compartmentalized, or additions could be made by adding on to this pull request, at your option.

https://user-images.githubusercontent.com/38897201/147321162-f569d635-8a1a-477a-8db4-e4e8575dd57a.mp4

#### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update (I'm not sure about this one?)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not quite sure what's being referred to here, but i will be happy to provide documentation)
- [x] My changes generate no new warnings




















<!-- Replace -->
Preview: https://61ca18d56b639f14dec31c14--pr-cinny.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
