### PR TITLE
[Enhancement] Use jumbo emoji for short emoji-only messages

### DIFF
--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -172,14 +172,14 @@ const MessageBody = React.memo(({
   // if body is not string it is a React element.
   if (typeof body !== 'string') return <div className="message__body">{body}</div>;
 
-  const content = isCustomHTML
+  let content = isCustomHTML
     ? twemojify(sanitizeCustomHtml(body), undefined, true, false)
     : twemojify(body, undefined, true);
 
   // Determine if this message should render with large emojis
   // Criteria:
   // - Contains only emoji
-  // - Contains no more than six emoji
+  // - Contains no more than 10 emoji
   let emojiOnly = false;
   if (content.type === 'img') {
     // If this messages contains only a single (inline) image
@@ -191,7 +191,7 @@ const MessageBody = React.memo(({
     const nEmojis = content.filter((e) => e.type === 'img').length;
 
     // Make sure there's no text besides whitespace
-    if (nEmojis <= 6 && content.every((element) => (
+    if (nEmojis <= 10 && content.every((element) => (
       (typeof element === 'object' && element.type === 'img')
       || (typeof element === 'string' && /^\s*$/g.test(element))
     ))) {
@@ -199,9 +199,15 @@ const MessageBody = React.memo(({
     }
   }
 
+  if (!isCustomHTML) {
+    // If this is a plaintext message, wrap it in a <p> element (automatically applying
+    // white-space: pre-wrap) in order to preserve newlines
+    content = (<p>{content}</p>);
+  }
+
   return (
     <div className="message__body">
-      <div className={`text text-b1 ${emojiOnly ? 'emoji-only' : ''}`}>
+      <div className={`text ${emojiOnly ? 'text-h1' : 'text-b1'}`}>
         { msgType === 'm.emote' && (
           <>
             {'* '}

--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -174,11 +174,34 @@ const MessageBody = React.memo(({
 
   const content = isCustomHTML
     ? twemojify(sanitizeCustomHtml(body), undefined, true, false)
-    : <p>{twemojify(body, undefined, true)}</p>;
+    : twemojify(body, undefined, true);
+
+  // Determine if this message should render with large emojis
+  // Criteria:
+  // - Contains only emoji
+  // - Contains no more than six emoji
+  let emojiOnly = false;
+  if (content.type === 'img') {
+    // If this messages contains only a single (inline) image
+    emojiOnly = true;
+  } else if (content.constructor.name === 'Array') {
+    // Otherwise, it might be an array of images / texb
+
+    // Count the number of emojis
+    const nEmojis = content.filter((e) => e.type === 'img').length;
+
+    // Make sure there's no text besides whitespace
+    if (nEmojis <= 6 && content.every((element) => (
+      (typeof element === 'object' && element.type === 'img')
+      || (typeof element === 'string' && /^\s*$/g.test(element))
+    ))) {
+      emojiOnly = true;
+    }
+  }
 
   return (
     <div className="message__body">
-      <div className="text text-b1">
+      <div className={`text text-b1 ${emojiOnly ? 'emoji-only' : ''}`}>
         { msgType === 'm.emote' && (
           <>
             {'* '}

--- a/src/app/molecules/message/Message.scss
+++ b/src/app/molecules/message/Message.scss
@@ -196,10 +196,6 @@
     }
   }
 
-  & > .emoji-only img {
-    height: 64px !important;
-  }
-
   .data-mx-spoiler--visible {
     background-color: var(--bg-surface-active) !important;
     color: inherit !important;

--- a/src/app/molecules/message/Message.scss
+++ b/src/app/molecules/message/Message.scss
@@ -195,6 +195,11 @@
       opacity: 0;
     }
   }
+
+  & > .emoji-only img {
+    height: 64px !important;
+  }
+
   .data-mx-spoiler--visible {
     background-color: var(--bg-surface-active) !important;
     color: inherit !important;


### PR DESCRIPTION
### Description

Closes #204

Emoji are currently displayed using a small, inline size whenever sent in a message.  This pull request adds a special case where a message consists only of up to 6 emoji and whitespace.  For these messages, emoji are displayed at 64px.  This feature is sometimes referred to as "Jumbo Emoji".  For more details about this change and it's motivations, please see issue #204.

![image](https://user-images.githubusercontent.com/38897201/147419081-231388a7-5060-4617-a66b-7e828ff32d2b.png)

One thing I wanted to ask before this was merged - in order to make detecting the number of emoji easier, I removed a `<p>` tag around messages without explicit HTML formatting (which can still contain twemoji).  As far as I can tell, this shouldn't break anything, especially because HTML formatted messages are displayed without being wrapped in a `<p>` tag, so I think that this tag was vestigial.  However, I wanted to double check with you, since you have a much better understanding of the codebase than me, and would be more likely to know  if this was relevant.

#### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings





<!-- Replace -->
Preview: https://61c9453e4bd53f4dbf189c70--pr-cinny.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
