### PR TITLE
Add support for sending room-local emoji

### DIFF
--- a/src/app/organisms/emoji-board/custom-emoji.js
+++ b/src/app/organisms/emoji-board/custom-emoji.js
@@ -94,11 +94,7 @@ function getUserImagePack(mx) {
 function getPacksInRoom(room) {
   const packs = room.currentState.getStateEvents('im.ponies.room_emotes');
 
-  if (!packs) {
-    return [];
-  }
-
-  return Array.from(packs.values())
+  return packs
     .map((p) => ImagePack.parsePack(p.event.content, room))
     .filter((p) => p !== null);
 }

--- a/src/app/organisms/emoji-board/custom-emoji.js
+++ b/src/app/organisms/emoji-board/custom-emoji.js
@@ -71,9 +71,7 @@ function getUserEmoji(mx) {
 // Returns a list of `ImagePack`s.  This does not include packs in spaces that contain
 // this room.
 function getPacksInRoom(room) {
-  const packs = room.currentState
-    .events
-    .get('im.ponies.room_emotes');
+  const packs = room.currentState.getStateEvents('im.ponies.room_emotes');
 
   if (!packs) {
     return [];

--- a/src/app/organisms/emoji-board/custom-emoji.js
+++ b/src/app/organisms/emoji-board/custom-emoji.js
@@ -19,7 +19,7 @@ class ImagePack {
   // The room argument is the room the pack exists in, which is used as a fallback for
   // missing properties
   constructor(rawPack, room) {
-    const { pack } = rawPack;
+    const pack = rawPack.pack ?? {};
 
     this.displayName = pack.display_name ?? (room ? room.name : undefined);
     this.avatar = pack.avatar_url ?? (room ? room.getMxcAvatarUrl() : undefined);

--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -210,7 +210,7 @@ function RoomViewCmdBar({ roomId, roomTimeline, viewEvent }) {
         setCmd({ prefix, suggestions: commands });
       },
       ':': () => {
-        const emojis = getEmojiForCompletion(mx);
+        const emojis = getEmojiForCompletion(mx.getRoom(roomId));
         asyncSearch.setup(emojis, { keys: ['shortcode'], isContain: true, limit: 20 });
         setCmd({ prefix, suggestions: emojis.slice(26, 46) });
       },

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -205,8 +205,8 @@ class RoomsInput extends EventEmitter {
   //
   // This includes inserting any custom emoji that might be relevant, and (only if the
   // user has enabled it in their settings) formatting the message using markdown.
-  formatAndEmojifyText(text) {
-    const allEmoji = getShortcodeToEmoji(this.matrixClient);
+  static formatAndEmojifyText(room, text) {
+    const allEmoji = getShortcodeToEmoji(room);
 
     // Start by applying markdown formatting (if relevant)
     let formattedText;
@@ -265,7 +265,10 @@ class RoomsInput extends EventEmitter {
       };
 
       // Apply formatting if relevant
-      const formattedBody = this.formatAndEmojifyText(input.message);
+      const formattedBody = RoomsInput.formatAndEmojifyText(
+        this.matrixClient.getRoom(roomId),
+        input.message,
+      );
       if (formattedBody !== input.message) {
         // Formatting was applied, and we need to switch to custom HTML
         content.format = 'org.matrix.custom.html';

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -113,6 +113,54 @@ function bindReplyToContent(roomId, reply, content) {
   return newContent;
 }
 
+// Apply formatting to a plain text message
+//
+// This includes inserting any custom emoji that might be relevant, and (only if the
+// user has enabled it in their settings) formatting the message using markdown.
+function formatAndEmojifyText(room, text) {
+  const allEmoji = getShortcodeToEmoji(room);
+
+  // Start by applying markdown formatting (if relevant)
+  let formattedText;
+  if (settings.isMarkdown) {
+    formattedText = getFormattedBody(text);
+  } else {
+    formattedText = text;
+  }
+
+  // Check to see if there are any :shortcode-style-tags: in the message
+  Array.from(formattedText.matchAll(/\B:([\w-]+):\B/g))
+    // Then filter to only the ones corresponding to a valid emoji
+    .filter((match) => allEmoji.has(match[1]))
+    // Reversing the array ensures that indices are preserved as we start replacing
+    .reverse()
+    // Replace each :shortcode: with an <img/> tag
+    .forEach((shortcodeMatch) => {
+      const emoji = allEmoji.get(shortcodeMatch[1]);
+
+      // Render the tag that will replace the shortcode
+      let tag;
+      if (emoji.mxc) {
+        tag = `<img data-mx-emoticon="" src="${
+          emoji.mxc
+        }" alt=":${
+          emoji.shortcode
+        }:" title=":${
+          emoji.shortcode
+        }:" height="32" />`;
+      } else {
+        tag = emoji.unicode;
+      }
+
+      // Splice the tag into the text
+      formattedText = formattedText.substr(0, shortcodeMatch.index)
+        + tag
+        + formattedText.substr(shortcodeMatch.index + shortcodeMatch[0].length);
+    });
+
+  return formattedText;
+}
+
 class RoomsInput extends EventEmitter {
   constructor(mx) {
     super();
@@ -201,54 +249,6 @@ class RoomsInput extends EventEmitter {
     return this.roomIdToInput.get(roomId)?.isSending || false;
   }
 
-  // Apply formatting to a plain text message
-  //
-  // This includes inserting any custom emoji that might be relevant, and (only if the
-  // user has enabled it in their settings) formatting the message using markdown.
-  static formatAndEmojifyText(room, text) {
-    const allEmoji = getShortcodeToEmoji(room);
-
-    // Start by applying markdown formatting (if relevant)
-    let formattedText;
-    if (settings.isMarkdown) {
-      formattedText = getFormattedBody(text);
-    } else {
-      formattedText = text;
-    }
-
-    // Check to see if there are any :shortcode-style-tags: in the message
-    Array.from(formattedText.matchAll(/\B:([\w-]+):\B/g))
-      // Then filter to only the ones corresponding to a valid emoji
-      .filter((match) => allEmoji.has(match[1]))
-      // Reversing the array ensures that indices are preserved as we start replacing
-      .reverse()
-      // Replace each :shortcode: with an <img/> tag
-      .forEach((shortcodeMatch) => {
-        const emoji = allEmoji.get(shortcodeMatch[1]);
-
-        // Render the tag that will replace the shortcode
-        let tag;
-        if (emoji.mxc) {
-          tag = `<img data-mx-emoticon="" src="${
-            emoji.mxc
-          }" alt=":${
-            emoji.shortcode
-          }:" title=":${
-            emoji.shortcode
-          }:" height="32" />`;
-        } else {
-          tag = emoji.unicode;
-        }
-
-        // Splice the tag into the text
-        formattedText = formattedText.substr(0, shortcodeMatch.index)
-          + tag
-          + formattedText.substr(shortcodeMatch.index + shortcodeMatch[0].length);
-      });
-
-    return formattedText;
-  }
-
   async sendInput(roomId) {
     const input = this.getInput(roomId);
     input.isSending = true;
@@ -265,7 +265,7 @@ class RoomsInput extends EventEmitter {
       };
 
       // Apply formatting if relevant
-      const formattedBody = RoomsInput.formatAndEmojifyText(
+      const formattedBody = formatAndEmojifyText(
         this.matrixClient.getRoom(roomId),
         input.message,
       );
@@ -404,7 +404,7 @@ class RoomsInput extends EventEmitter {
     };
 
     // Apply formatting if relevant
-    const formattedBody = this.formatAndEmojifyText(editedBody);
+    const formattedBody = formatAndEmojifyText(editedBody);
     if (formattedBody !== editedBody) {
       content.formatted_body = ` * ${formattedBody}`;
       content.format = 'org.matrix.custom.html';

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -404,7 +404,10 @@ class RoomsInput extends EventEmitter {
     };
 
     // Apply formatting if relevant
-    const formattedBody = formatAndEmojifyText(editedBody);
+    const formattedBody = formatAndEmojifyText(
+      this.matrixClient.getRoom(roomId),
+      editedBody
+    );
     if (formattedBody !== editedBody) {
       content.formatted_body = ` * ${formattedBody}`;
       content.format = 'org.matrix.custom.html';


### PR DESCRIPTION
### Description

This pull request:
- Extends the available emoji to include emoji from emoji packs defined in the current room
- Performs some minor refactoring to embrace the Image Pack structuring of emoji, which will make the addition of this change and coming changes easier
  - In doing so, filters out stickers from the emoji picker

This pull request does not:
- Add support for use of packs external to the current room (e.g. packs in spaces)
- Allow users to use room emoji outside of the room they are defined in
- Do anything with stickers

Related issue #83 

### Tips for reviewing

You may want to check out the room #blobcats:the-apothecary.club for an example of an emoji pack in a room.  This certainly doesn't utilize all of the features of image packs (doesn't contain stickers, doesn't set a pack name / avi besides the inherited ones), but it works good enough for testing.

#### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

















<!-- Replace -->
Preview: https://61cbe28f1fd3346e45318820--pr-cinny.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
