### PR TITLE
Add custom emoji to emoji picker

### DIFF
--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -249,39 +249,42 @@ function EmojiBoard({ onSelect }) {
           <Text>:slight_smile:</Text>
         </div>
       </div>
-      <div className="emoji-board__nav">
-        {
-          availableEmojis.map((pack) => (
-            // TODO (future PR?):  Use the pack icon, and only use StarIC as a fallback
-            <IconButton
-              onClick={() => openGroup(pack.packIndex)}
-              src={StarIC}
-              key={pack.packIndex}
-              tooltip={pack.displayName}
-              tooltipPlacement="right" />
-          ))
-        }
-        {
-          [
-            [0, EmojiIC, 'Smilies'],
-            [1, DogIC, 'Animals'],
-            [2, CupIC, 'Food'],
-            [3, BallIC, 'Activities'],
-            [4, PhotoIC, 'Travel'],
-            [5, BulbIC, 'Objects'],
-            [6, PeaceIC, 'Symbols'],
-            [7, FlagIC, 'Flags'],
-          ].map(([indx, ico, name]) => (
-            <IconButton
-              onClick={() => openGroup(availableEmojis.length + indx)}
-              key={indx}
-              src={ico}
-              tooltip={name}
-              tooltipPlacement="right"
-            />
-          ))
-        }
-      </div>
+      <ScrollView invisible>
+        <div className="emoji-board__nav">
+          {
+            availableEmojis.map((pack) => (
+              // TODO (future PR?):  Use the pack icon, and only use StarIC as a fallback
+              <IconButton
+                onClick={() => openGroup(pack.packIndex)}
+                src={StarIC}
+                key={pack.packIndex}
+                tooltip={pack.displayName}
+                tooltipPlacement="right"
+              />
+            ))
+          }
+          {
+            [
+              [0, EmojiIC, 'Smilies'],
+              [1, DogIC, 'Animals'],
+              [2, CupIC, 'Food'],
+              [3, BallIC, 'Activities'],
+              [4, PhotoIC, 'Travel'],
+              [5, BulbIC, 'Objects'],
+              [6, PeaceIC, 'Symbols'],
+              [7, FlagIC, 'Flags'],
+            ].map(([indx, ico, name]) => (
+              <IconButton
+                onClick={() => openGroup(availableEmojis.length + indx)}
+                key={indx}
+                src={ico}
+                tooltip={name}
+                tooltipPlacement="right"
+              />
+            ))
+          }
+        </div>
+      </ScrollView>
     </div>
   );
 }

--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -46,6 +46,7 @@ function EmojiGroup({ name, groupEmojis }) {
           <span key={emojiIndex}>
             {
               emoji.hexcode
+                // This is a unicode emoji, and should be rendered with twemoji
                 ? parse(twemoji.parse(
                   emoji.unicode,
                   {
@@ -56,6 +57,7 @@ function EmojiGroup({ name, groupEmojis }) {
                     }),
                   },
                 ))
+                // This is a custom emoji, and should be render as an mxc
                 : (
                   <img
                     className="emoji"
@@ -186,18 +188,24 @@ function EmojiBoard({ onSelect }) {
 
   const [availableEmojis, setAvailableEmojis] = useState([]);
 
+  // This should be called whenever the room changes, so that we can switch out the emoji
+  // for whatever packs are relevant to this room
   function updateAvailableEmoji(selectedRoomId) {
+    // Retrieve the packs for the new room
     const packs = getRelevantPacks(
       initMatrix.matrixClient.getRoom(selectedRoomId),
     );
 
+    // Set an index for each pack so that we know where to jump when the user uses the nav
     for (let i = 0; i < packs.length; i += 1) {
       packs[i].packIndex = i;
     }
 
+    // Update the component state
     setAvailableEmojis(packs);
   }
 
+  // Register the above function as an event listener
   useEffect(() => {
     navigation.on(cons.events.navigation.ROOM_SELECTED, updateAvailableEmoji);
     return () => {

--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -63,7 +63,8 @@ function EmojiGroup({ name, groupEmojis }) {
                     alt={emoji.shortcode}
                     unicode={`:${emoji.shortcode}:`}
                     shortcodes={emoji.shortcode}
-                    src={initMatrix.matrixClient.mxcUrlToHttp(emoji.mxc)}
+                    src={initMatrix.matrixClient.mxcUrlToHttp(emoji.mxc, 38, 38, 'crop')}
+                    data-mx-emoticon
                   />
                 )
             }

--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -194,7 +194,11 @@ function EmojiBoard({ onSelect }) {
     // Retrieve the packs for the new room
     const packs = getRelevantPacks(
       initMatrix.matrixClient.getRoom(selectedRoomId),
-    );
+    )
+    // Remove packs that aren't marked as emoji packs
+      .filter((pack) => pack.usage.indexOf('emoticon') !== -1)
+    // Remove packs without emojis
+      .filter((pack) => pack.getEmojis().length !== 0);
 
     // Set an index for each pack so that we know where to jump when the user uses the nav
     for (let i = 0; i < packs.length; i += 1) {

--- a/src/app/organisms/emoji-board/EmojiBoard.scss
+++ b/src/app/organisms/emoji-board/EmojiBoard.scss
@@ -10,6 +10,10 @@
     height: 400px;
     width: 286px;
   }
+  & > .scrollbar {
+    width: initial;
+    height: 400px;
+  }
   &__nav {
     @extend .cp-fx__column;
     justify-content: center;

--- a/src/app/organisms/emoji-board/custom-emoji.js
+++ b/src/app/organisms/emoji-board/custom-emoji.js
@@ -166,4 +166,6 @@ function getEmojiForCompletion(room) {
     .concat(Array.from(allEmoji.values()));
 }
 
-export { getUserImagePack, getShortcodeToEmoji, getEmojiForCompletion };
+export {
+  getUserImagePack, getShortcodeToEmoji, getRelevantPacks, getEmojiForCompletion,
+};


### PR DESCRIPTION
### Description

Now that custom room & user emoji have been implemented, we probably want to add them to the emoji picker as well, for consistency, and also so that people can see what emoji are available.  This PR does just that.

https://user-images.githubusercontent.com/38897201/147629337-262d0201-ea97-453c-8d5c-ff4271f00acc.mp4

For the sake of keeping this PR from getting out of hand, there are a few things this PR is missing or doesn't do:
- Currently, a star icon is used for all custom emoji packs.  We likely want to use the pack icon here in the future, but this will likely require a fair bit more code, so is left out for now.
- Now that there are more emoji categories, the category list can scroll in some cases.  We should synchronize the scroll position of the main body with that of the category list, to improve discoverability of this fact.  This is probably going to require a good bit of logic though
- The emoji picker shows custom emoji for reactions, although sending reactions isn't implemented yet

Also, I'm getting a bit out of my league for the depth of my knowledge of ReactJS, so I apologize for anything I'm doing in an inefficient or unidiomatic way.  If you catch anything like that, please let me know so I can get better :heart: 

Related Issue #83 

#### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings





<!-- Replace -->
Preview: https://61cd2c548b3f2792c80aafdb--pr-cinny.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
