### PR TITLE
Update build-pull-request.yml to use npm ci

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Build
-              run: npm install && npm run build
+              run: npm ci && npm run build
             - name: Upload Artifact
               uses: actions/upload-artifact@v2
               with:


### PR DESCRIPTION
Use npm ci over npm install in building PR.

<!-- Replace -->
Preview: https://61f6a3e3cb2dcf01127cd258--pr-cinny.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
