### PR TITLE
Create icons for users without an avatar in notifications

### DIFF
--- a/src/app/atoms/avatar/Avatar.jsx
+++ b/src/app/atoms/avatar/Avatar.jsx
@@ -8,6 +8,7 @@ import Text from '../text/Text';
 import RawIcon from '../system-icons/RawIcon';
 
 import ImageBrokenSVG from '../../../../public/res/svg/image-broken.svg';
+import { avatarInitials } from '../../../util/common';
 
 function Avatar({
   text, bgColor, iconSrc, iconColor, imageSrc, size,
@@ -40,7 +41,7 @@ function Avatar({
                   ? <RawIcon size={size} src={iconSrc} color={iconColor} />
                   : text !== null && (
                     <Text variant={textSize} primary>
-                      {twemojify([...text][0])}
+                      {twemojify(avatarInitials(text))}
                     </Text>
                   )
               }

--- a/src/app/atoms/avatar/render.js
+++ b/src/app/atoms/avatar/render.js
@@ -6,22 +6,25 @@ function cssVar(name) {
 
 // renders the avatar and returns it as an URL
 export default async function renderAvatar({
-  text, bgColor, imageSrc, size, borderRadius,
+  text, bgColor, imageSrc, size, borderRadius, multiplier,
 }) {
   try {
+    const mSize = size * multiplier;
+    const mBorderRadius = borderRadius * multiplier;
+
     const canvas = document.createElement('canvas');
-    canvas.width = size;
-    canvas.height = size;
+    canvas.width = mSize;
+    canvas.height = mSize;
 
     const ctx = canvas.getContext('2d');
 
     // rounded corners
     ctx.beginPath();
-    ctx.moveTo(size, size);
-    ctx.arcTo(0, size, 0, 0, borderRadius);
-    ctx.arcTo(0, 0, size, 0, borderRadius);
-    ctx.arcTo(size, 0, size, size, borderRadius);
-    ctx.arcTo(size, size, 0, size, borderRadius);
+    ctx.moveTo(mSize, mSize);
+    ctx.arcTo(0, mSize, 0, 0, mBorderRadius);
+    ctx.arcTo(0, 0, mSize, 0, mBorderRadius);
+    ctx.arcTo(mSize, 0, mSize, mSize, mBorderRadius);
+    ctx.arcTo(mSize, mSize, 0, mSize, mBorderRadius);
 
     if (imageSrc) {
       // clip corners of image
@@ -37,17 +40,17 @@ export default async function renderAvatar({
       img.src = imageSrc;
       await promise;
 
-      ctx.drawImage(img, 0, 0, size, size);
+      ctx.drawImage(img, 0, 0, mSize, mSize);
     } else {
       // draw initials centered on the canvas
       ctx.fillStyle = cssVar(bgColor);
       ctx.fill();
 
       ctx.fillStyle = 'white';
-      ctx.font = `${cssVar('--fs-s1')} ${cssVar('--font-primary')}`;
+      ctx.font = `calc(${multiplier} * ${cssVar('--fs-s1')}) ${cssVar('--font-primary')}`;
       ctx.textBaseline = 'middle';
       ctx.textAlign = 'center';
-      ctx.fillText(avatarInitials(text), size / 2, size / 2);
+      ctx.fillText(avatarInitials(text), mSize / 2, mSize / 2);
     }
 
     return canvas.toDataURL();

--- a/src/app/atoms/avatar/render.js
+++ b/src/app/atoms/avatar/render.js
@@ -1,0 +1,58 @@
+import { avatarInitials } from '../../../util/common';
+
+function cssVar(name) {
+  return getComputedStyle(document.body).getPropertyValue(name);
+}
+
+// renders the avatar and returns it as an URL
+export default async function renderAvatar({
+  text, bgColor, imageSrc, size, borderRadius,
+}) {
+  try {
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+
+    const ctx = canvas.getContext('2d');
+
+    // rounded corners
+    ctx.beginPath();
+    ctx.moveTo(size, size);
+    ctx.arcTo(0, size, 0, 0, borderRadius);
+    ctx.arcTo(0, 0, size, 0, borderRadius);
+    ctx.arcTo(size, 0, size, size, borderRadius);
+    ctx.arcTo(size, size, 0, size, borderRadius);
+
+    if (imageSrc) {
+      // clip corners of image
+      ctx.closePath();
+      ctx.clip();
+
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      const promise = new Promise((resolve, reject) => {
+        img.onerror = reject;
+        img.onload = resolve;
+      });
+      img.src = imageSrc;
+      await promise;
+
+      ctx.drawImage(img, 0, 0, size, size);
+    } else {
+      // draw initials centered on the canvas
+      ctx.fillStyle = cssVar(bgColor);
+      ctx.fill();
+
+      ctx.fillStyle = 'white';
+      ctx.font = `${cssVar('--fs-s1')} ${cssVar('--font-primary')}`;
+      ctx.textBaseline = 'middle';
+      ctx.textAlign = 'center';
+      ctx.fillText(avatarInitials(text), size / 2, size / 2);
+    }
+
+    return canvas.toDataURL();
+  } catch (e) {
+    console.error(e);
+    return imageSrc;
+  }
+}

--- a/src/app/atoms/avatar/render.js
+++ b/src/app/atoms/avatar/render.js
@@ -6,25 +6,24 @@ function cssVar(name) {
 
 // renders the avatar and returns it as an URL
 export default async function renderAvatar({
-  text, bgColor, imageSrc, size, borderRadius, multiplier,
+  text, bgColor, imageSrc, size, borderRadius, scale,
 }) {
   try {
-    const mSize = size * multiplier;
-    const mBorderRadius = borderRadius * multiplier;
-
     const canvas = document.createElement('canvas');
-    canvas.width = mSize;
-    canvas.height = mSize;
+    canvas.width = size * scale;
+    canvas.height = size * scale;
 
     const ctx = canvas.getContext('2d');
 
+    ctx.scale(scale, scale);
+
     // rounded corners
     ctx.beginPath();
-    ctx.moveTo(mSize, mSize);
-    ctx.arcTo(0, mSize, 0, 0, mBorderRadius);
-    ctx.arcTo(0, 0, mSize, 0, mBorderRadius);
-    ctx.arcTo(mSize, 0, mSize, mSize, mBorderRadius);
-    ctx.arcTo(mSize, mSize, 0, mSize, mBorderRadius);
+    ctx.moveTo(size, size);
+    ctx.arcTo(0, size, 0, 0, borderRadius);
+    ctx.arcTo(0, 0, size, 0, borderRadius);
+    ctx.arcTo(size, 0, size, size, borderRadius);
+    ctx.arcTo(size, size, 0, size, borderRadius);
 
     if (imageSrc) {
       // clip corners of image
@@ -40,17 +39,18 @@ export default async function renderAvatar({
       img.src = imageSrc;
       await promise;
 
-      ctx.drawImage(img, 0, 0, mSize, mSize);
+      ctx.drawImage(img, 0, 0, size, size);
     } else {
-      // draw initials centered on the canvas
+      // colored background
       ctx.fillStyle = cssVar(bgColor);
       ctx.fill();
 
-      ctx.fillStyle = 'white';
-      ctx.font = `calc(${multiplier} * ${cssVar('--fs-s1')}) ${cssVar('--font-primary')}`;
+      // centered letter
+      ctx.fillStyle = '#fff';
+      ctx.font = `${cssVar('--fs-s1')} ${cssVar('--font-primary')}`;
       ctx.textBaseline = 'middle';
       ctx.textAlign = 'center';
-      ctx.fillText(avatarInitials(text), mSize / 2, mSize / 2);
+      ctx.fillText(avatarInitials(text), size / 2, size / 2);
     }
 
     return canvas.toDataURL();

--- a/src/client/state/Notifications.js
+++ b/src/client/state/Notifications.js
@@ -1,4 +1,6 @@
 import EventEmitter from 'events';
+import renderAvatar from '../../app/atoms/avatar/render';
+import { cssColorMXID } from '../../util/colorMXID';
 import { selectRoom } from '../action/navigation';
 import cons from './cons';
 import navigation from './navigation';
@@ -183,9 +185,18 @@ class Notifications extends EventEmitter {
       title = `${mEvent.sender.name} (${room.name})`;
     }
 
+    const iconSize = 42;
+    const icon = await renderAvatar({
+      text: mEvent.sender.name,
+      bgColor: cssColorMXID(mEvent.getSender()),
+      imageSrc: mEvent.sender?.getAvatarUrl(this.matrixClient.baseUrl, iconSize, iconSize, 'crop'),
+      size: iconSize,
+      borderRadius: 8,
+    });
+
     const noti = new window.Notification(title, {
       body: mEvent.getContent().body,
-      icon: mEvent.sender?.getAvatarUrl(this.matrixClient.baseUrl, 36, 36, 'crop'),
+      icon,
     });
     noti.onclick = () => selectRoom(room.roomId, mEvent.getId());
   }

--- a/src/client/state/Notifications.js
+++ b/src/client/state/Notifications.js
@@ -185,13 +185,14 @@ class Notifications extends EventEmitter {
       title = `${mEvent.sender.name} (${room.name})`;
     }
 
-    const iconSize = 42;
+    const iconSize = 36;
     const icon = await renderAvatar({
       text: mEvent.sender.name,
       bgColor: cssColorMXID(mEvent.getSender()),
       imageSrc: mEvent.sender?.getAvatarUrl(this.matrixClient.baseUrl, iconSize, iconSize, 'crop'),
       size: iconSize,
       borderRadius: 8,
+      multiplier: 4,
     });
 
     const noti = new window.Notification(title, {

--- a/src/client/state/Notifications.js
+++ b/src/client/state/Notifications.js
@@ -192,7 +192,7 @@ class Notifications extends EventEmitter {
       imageSrc: mEvent.sender?.getAvatarUrl(this.matrixClient.baseUrl, iconSize, iconSize, 'crop'),
       size: iconSize,
       borderRadius: 8,
-      multiplier: 4,
+      scale: 8,
     });
 
     const noti = new window.Notification(title, {

--- a/src/util/colorMXID.js
+++ b/src/util/colorMXID.js
@@ -1,16 +1,6 @@
 // https://github.com/cloudrac3r/cadencegq/blob/master/pug/mxid.pug
 
-const colors = [
-  'var(--mx-uc-1)',
-  'var(--mx-uc-2)',
-  'var(--mx-uc-3)',
-  'var(--mx-uc-4)',
-  'var(--mx-uc-5)',
-  'var(--mx-uc-6)',
-  'var(--mx-uc-7)',
-  'var(--mx-uc-8)',
-];
-function hashCode(str) {
+export function hashCode(str) {
   let hash = 0;
   let i;
   let chr;
@@ -26,7 +16,12 @@ function hashCode(str) {
   }
   return Math.abs(hash);
 }
-export default function colorMXID(userId) {
+
+export function cssColorMXID(userId) {
   const colorNumber = hashCode(userId) % 8;
-  return colors[colorNumber];
+  return `--mx-uc-${colorNumber + 1}`;
+}
+
+export default function colorMXID(userId) {
+  return `var(${cssColorMXID(userId)})`;
 }

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -110,3 +110,7 @@ export function getScrollInfo(target) {
   scroll.isScrollable = scroll.height > scroll.viewHeight;
   return scroll;
 }
+
+export function avatarInitials(text) {
+  return [...text][0];
+}


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

### Description

Create icons for users without an avatar.
Round notification icons (for image icons as well).

#### Windows 10
![image](https://user-images.githubusercontent.com/35173023/152660888-e913eeac-dfff-45f1-9269-5755284f19d3.png)
![image](https://user-images.githubusercontent.com/35173023/152660832-f0cdb83b-21ed-4d16-811e-0713b86dde8c.png)

#### GNOME
![image](https://user-images.githubusercontent.com/35173023/152660674-69cba16a-5154-40e4-9782-7d72568cf96a.png)
![image](https://user-images.githubusercontent.com/35173023/152660627-1a1f3533-d9a2-4f1d-bd75-e40b1d3eb546.png)

#### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings





<!-- Replace -->
Preview: https://620a77154246f82b33263a4b--pr-cinny.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
