### PR TITLE
Prevent crash when opening room permission on conduit homeserver

### DIFF
--- a/src/app/molecules/room-permissions/RoomPermissions.jsx
+++ b/src/app/molecules/room-permissions/RoomPermissions.jsx
@@ -233,8 +233,9 @@ function RoomPermissions({ roomId }) {
 
                   let powerLevel = 0;
                   let permValue = permInfo.parent
-                    ? permissions[permInfo.parent][permKey]
-                    : permissions[permKey];
+                    ? permissions[permInfo.parent]
+                    : permissions;
+                  permValue = permValue ? permValue[permKey] : permInfo.default;
 
                   if (!permValue) permValue = permInfo.default;
 

--- a/src/app/molecules/room-permissions/RoomPermissions.jsx
+++ b/src/app/molecules/room-permissions/RoomPermissions.jsx
@@ -233,9 +233,8 @@ function RoomPermissions({ roomId }) {
 
                   let powerLevel = 0;
                   let permValue = permInfo.parent
-                    ? permissions[permInfo.parent]
-                    : permissions;
-                  permValue = permValue ? permValue[permKey] : permInfo.default;
+                    ? permissions[permInfo.parent]?.[permKey]
+                    : permissions[permKey];
 
                   if (!permValue) permValue = permInfo.default;
 


### PR DESCRIPTION
### Description

This prevents the room permission tab from crashing Cinny on the Conduit homeserver by showing the default power levels if the homeserver does not include it in its response.

Fixes #310

#### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings








<!-- Replace -->
Preview: https://620a70c20c5bd51abd924e29--pr-cinny.netlify.app
⚠️ Do you trust the author of this PR? Maybe this build will steal your keys or give you malware. Exercise caution. Use test accounts.
<!-- Replace -->
