### PR TITLE
Fix not all emoji-only messages being detected as such

### DIFF
--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -201,10 +201,10 @@ const MessageBody = React.memo(({
     // Count the number of emojis
     const nEmojis = content.filter((e) => e.type === 'img').length;
 
-    // Make sure there's no text besides whitespace
+    // Make sure there's no text besides whitespace and variation selector U+FE0F
     if (nEmojis <= 10 && content.every((element) => (
       (typeof element === 'object' && element.type === 'img')
-      || (typeof element === 'string' && /^\s*$/g.test(element))
+      || (typeof element === 'string' && /^[\s\ufe0f]*$/g.test(element))
     ))) {
       emojiOnly = true;
     }


### PR DESCRIPTION
### Description

Some emoji-only messages were not considered emoji-only because of a unicode variation selector (U+FE0F) being sent along.

Without the fix (:+1: are smaller than the other emojis)
![image](https://user-images.githubusercontent.com/35173023/157464536-c4223271-0358-4fc3-a922-af512ebb2ea8.png)

With the fix
![image](https://user-images.githubusercontent.com/35173023/157464966-fda7d0f9-9f47-4d3e-b2be-d9f41e731be4.png)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- Replace -->
Preview: https://6228bebac3982500664037c5--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
