### PR TITLE
Add recently used section to emoji board

### DIFF
--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -21,6 +21,7 @@ import Input from '../../atoms/input/Input';
 import ScrollView from '../../atoms/scroll/ScrollView';
 
 import SearchIC from '../../../../public/res/ic/outlined/search.svg';
+import HeartIC from '../../../../public/res/ic/outlined/heart.svg';
 import EmojiIC from '../../../../public/res/ic/outlined/emoji.svg';
 import DogIC from '../../../../public/res/ic/outlined/dog.svg';
 import CupIC from '../../../../public/res/ic/outlined/cup.svg';
@@ -193,6 +194,8 @@ function EmojiBoard({ onSelect, searchRef }) {
   const [availableEmojis, setAvailableEmojis] = useState([]);
   const [recentEmojis, setRecentEmojis] = useState([]);
 
+  const recentOffset = recentEmojis.length > 0 ? 1 : 0;
+
   useEffect(() => {
     const updateAvailableEmoji = (selectedRoomId) => {
       if (!selectedRoomId) {
@@ -237,7 +240,7 @@ function EmojiBoard({ onSelect, searchRef }) {
     const $emojiContent = scrollEmojisRef.current.firstElementChild;
     const groupCount = $emojiContent.childElementCount;
     if (groupCount > emojiGroups.length) {
-      tabIndex += groupCount - emojiGroups.length - availableEmojis.length;
+      tabIndex += groupCount - emojiGroups.length - availableEmojis.length - recentOffset;
     }
     $emojiContent.children[tabIndex].scrollIntoView();
   }
@@ -279,13 +282,21 @@ function EmojiBoard({ onSelect, searchRef }) {
       </div>
       <ScrollView invisible>
         <div className="emoji-board__nav">
+          {recentEmojis.length > 0 && (
+            <IconButton
+              onClick={() => openGroup(0)}
+              src={HeartIC}
+              tooltip="Recent"
+              tooltipPlacement="right"
+            />
+          )}
           <div className="emoji-board__nav-custom">
             {
               availableEmojis.map((pack) => {
                 const src = initMatrix.matrixClient.mxcUrlToHttp(pack.avatar ?? pack.images[0].mxc);
                 return (
                   <IconButton
-                    onClick={() => openGroup(pack.packIndex)}
+                    onClick={() => openGroup(recentOffset + pack.packIndex)}
                     src={src}
                     key={pack.packIndex}
                     tooltip={pack.displayName}
@@ -309,7 +320,7 @@ function EmojiBoard({ onSelect, searchRef }) {
                 [7, FlagIC, 'Flags'],
               ].map(([indx, ico, name]) => (
                 <IconButton
-                  onClick={() => openGroup(availableEmojis.length + indx)}
+                  onClick={() => openGroup(recentOffset + availableEmojis.length + indx)}
                   key={indx}
                   src={ico}
                   tooltip={name}

--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -152,7 +152,7 @@ function EmojiBoard({ onSelect, searchRef }) {
 
     const emoji = getEmojiDataFromTarget(e.target);
     onSelect(emoji);
-    addRecentEmoji(emoji.unicode);
+    if (emoji.hexcode) addRecentEmoji(emoji.unicode);
   }
 
   function setEmojiInfo(emoji) {

--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -21,7 +21,7 @@ import Input from '../../atoms/input/Input';
 import ScrollView from '../../atoms/scroll/ScrollView';
 
 import SearchIC from '../../../../public/res/ic/outlined/search.svg';
-import HeartIC from '../../../../public/res/ic/outlined/heart.svg';
+import RecentClockIC from '../../../../public/res/ic/outlined/recent-clock.svg';
 import EmojiIC from '../../../../public/res/ic/outlined/emoji.svg';
 import DogIC from '../../../../public/res/ic/outlined/dog.svg';
 import CupIC from '../../../../public/res/ic/outlined/cup.svg';
@@ -285,7 +285,7 @@ function EmojiBoard({ onSelect, searchRef }) {
           {recentEmojis.length > 0 && (
             <IconButton
               onClick={() => openGroup(0)}
-              src={HeartIC}
+              src={RecentClockIC}
               tooltip="Recent"
               tooltipPlacement="right"
             />

--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -12,6 +12,7 @@ import initMatrix from '../../../client/initMatrix';
 import cons from '../../../client/state/cons';
 import navigation from '../../../client/state/navigation';
 import AsyncSearch from '../../../util/AsyncSearch';
+import { addRecentEmoji, getRecentEmojis } from './recent';
 
 import Text from '../../atoms/text/Text';
 import RawIcon from '../../atoms/system-icons/RawIcon';
@@ -29,10 +30,11 @@ import BulbIC from '../../../../public/res/ic/outlined/bulb.svg';
 import PeaceIC from '../../../../public/res/ic/outlined/peace.svg';
 import FlagIC from '../../../../public/res/ic/outlined/flag.svg';
 
+const ROW_EMOJIS_COUNT = 7;
+
 const EmojiGroup = React.memo(({ name, groupEmojis }) => {
   function getEmojiBoard() {
     const emojiBoard = [];
-    const ROW_EMOJIS_COUNT = 7;
     const totalEmojis = groupEmojis.length;
 
     for (let r = 0; r < totalEmojis; r += ROW_EMOJIS_COUNT) {
@@ -147,8 +149,9 @@ function EmojiBoard({ onSelect, searchRef }) {
   function selectEmoji(e) {
     if (isTargetNotEmoji(e.target)) return;
 
-    const emoji = e.target;
-    onSelect(getEmojiDataFromTarget(emoji));
+    const emoji = getEmojiDataFromTarget(e.target);
+    onSelect(emoji);
+    addRecentEmoji(emoji.unicode);
   }
 
   function setEmojiInfo(emoji) {
@@ -188,6 +191,7 @@ function EmojiBoard({ onSelect, searchRef }) {
   }
 
   const [availableEmojis, setAvailableEmojis] = useState([]);
+  const [recentEmojis, setRecentEmojis] = useState([]);
 
   useEffect(() => {
     const updateAvailableEmoji = (selectedRoomId) => {
@@ -215,6 +219,9 @@ function EmojiBoard({ onSelect, searchRef }) {
     const onOpen = () => {
       searchRef.current.value = '';
       handleSearchChange();
+
+      // only update when board is getting opened to prevent shifting UI
+      setRecentEmojis(getRecentEmojis(3 * ROW_EMOJIS_COUNT));
     };
 
     navigation.on(cons.events.navigation.ROOM_SELECTED, updateAvailableEmoji);
@@ -246,6 +253,7 @@ function EmojiBoard({ onSelect, searchRef }) {
           <ScrollView ref={scrollEmojisRef} autoHide>
             <div onMouseMove={hoverEmoji} onClick={selectEmoji}>
               <SearchedEmoji />
+              {recentEmojis.length > 0 && <EmojiGroup name="Recently used" groupEmojis={recentEmojis} />}
               {
                 availableEmojis.map((pack) => (
                   <EmojiGroup

--- a/src/app/organisms/emoji-board/recent.js
+++ b/src/app/organisms/emoji-board/recent.js
@@ -8,10 +8,15 @@ function getRecentEmojisRaw() {
 }
 
 export function getRecentEmojis(limit) {
-  return getRecentEmojisRaw()
+  const res = [];
+  getRecentEmojisRaw()
     .sort((a, b) => b[1] - a[1])
-    .slice(0, limit)
-    .map(([unicode]) => emojis.find((e) => e.unicode === unicode));
+    .find(([unicode]) => {
+      const emoji = emojis.find((e) => e.unicode === unicode);
+      if (emoji) return res.push(emoji) >= limit;
+      return false;
+    });
+  return res;
 }
 
 export function addRecentEmoji(unicode) {

--- a/src/app/organisms/emoji-board/recent.js
+++ b/src/app/organisms/emoji-board/recent.js
@@ -3,19 +3,19 @@ import { emojis } from './emoji';
 
 const eventType = 'io.element.recent_emoji';
 
-function get() {
+function getRecentEmojisRaw() {
   return initMatrix.matrixClient.getAccountData(eventType).getContent().recent_emoji ?? [];
 }
 
 export function getRecentEmojis(limit) {
-  return get()
+  return getRecentEmojisRaw()
     .sort((a, b) => b[1] - a[1])
     .slice(0, limit)
     .map(([unicode]) => emojis.find((e) => e.unicode === unicode));
 }
 
 export function addRecentEmoji(unicode) {
-  const recent = get();
+  const recent = getRecentEmojisRaw();
   const i = recent.findIndex(([u]) => u === unicode);
   let entry;
   if (i < 0) {

--- a/src/app/organisms/emoji-board/recent.js
+++ b/src/app/organisms/emoji-board/recent.js
@@ -1,0 +1,27 @@
+import initMatrix from '../../../client/initMatrix';
+import { emojis } from './emoji';
+
+const eventType = 'io.element.recent_emoji';
+
+export function addRecentEmoji(unicode) {
+  const mx = initMatrix.matrixClient;
+  const recent = mx.getAccountData(eventType).getContent().recent_emoji;
+  const i = recent.findIndex(([u]) => u === unicode);
+  let entry;
+  if (i < 0) {
+    entry = [unicode, 1];
+  } else {
+    [entry] = recent.splice(i, 1);
+    entry[1] += 1;
+  }
+  recent.unshift(entry);
+  mx.setAccountData(eventType, { recent_emoji: recent });
+}
+
+export function getRecentEmojis(limit) {
+  const recentList = initMatrix.matrixClient.getAccountData(eventType).getContent().recent_emoji;
+  return recentList
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([unicode]) => emojis.find((e) => e.unicode === unicode));
+}

--- a/src/app/organisms/emoji-board/recent.js
+++ b/src/app/organisms/emoji-board/recent.js
@@ -25,5 +25,7 @@ export function addRecentEmoji(unicode) {
     entry[1] += 1;
   }
   recent.unshift(entry);
-  initMatrix.matrixClient.setAccountData(eventType, { recent_emoji: recent });
+  initMatrix.matrixClient.setAccountData(eventType, {
+    recent_emoji: recent.slice(0, 100),
+  });
 }

--- a/src/app/organisms/emoji-board/recent.js
+++ b/src/app/organisms/emoji-board/recent.js
@@ -3,9 +3,19 @@ import { emojis } from './emoji';
 
 const eventType = 'io.element.recent_emoji';
 
+function get() {
+  return initMatrix.matrixClient.getAccountData(eventType).getContent().recent_emoji ?? [];
+}
+
+export function getRecentEmojis(limit) {
+  return get()
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([unicode]) => emojis.find((e) => e.unicode === unicode));
+}
+
 export function addRecentEmoji(unicode) {
-  const mx = initMatrix.matrixClient;
-  const recent = mx.getAccountData(eventType).getContent().recent_emoji;
+  const recent = get();
   const i = recent.findIndex(([u]) => u === unicode);
   let entry;
   if (i < 0) {
@@ -15,13 +25,5 @@ export function addRecentEmoji(unicode) {
     entry[1] += 1;
   }
   recent.unshift(entry);
-  mx.setAccountData(eventType, { recent_emoji: recent });
-}
-
-export function getRecentEmojis(limit) {
-  const recentList = initMatrix.matrixClient.getAccountData(eventType).getContent().recent_emoji;
-  return recentList
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, limit)
-    .map(([unicode]) => emojis.find((e) => e.unicode === unicode));
+  initMatrix.matrixClient.setAccountData(eventType, { recent_emoji: recent });
 }

--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -21,6 +21,7 @@ import AsyncSearch from '../../../util/AsyncSearch';
 import Text from '../../atoms/text/Text';
 import ScrollView from '../../atoms/scroll/ScrollView';
 import FollowingMembers from '../../molecules/following-members/FollowingMembers';
+import { addRecentEmoji } from '../emoji-board/recent';
 
 const commands = [{
   name: 'markdown',
@@ -237,6 +238,7 @@ function RoomViewCmdBar({ roomId, roomTimeline, viewEvent }) {
       viewEvent.emit('cmd_fired');
     }
     if (myCmd.prefix === ':') {
+      if (!myCmd.result.mxc) addRecentEmoji(myCmd.result.unicode);
       viewEvent.emit('cmd_fired', {
         replace: myCmd.result.mxc ? `:${myCmd.result.shortcode}: ` : myCmd.result.unicode,
       });


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

### Description

Adds a recently used section (like element web has) to the emoji board.
Currently the icon in the sidebar is a heart. Personally I would think a clock would make for a better fit. I'm not a good designer though so I would leave the icon choice to @ajbura.

![image](https://user-images.githubusercontent.com/35173023/157674652-7ac02aed-3d38-47c0-a92a-d446f3e167fb.png)

Fixes #194

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings














<!-- Replace -->
Preview: https://62331f8e1ac2861711b137df--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
