### PR TITLE
Fix view source shows original event for an edited message

### DIFF
--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -469,6 +469,18 @@ function isMedia(mE) {
   );
 }
 
+// if editedTimeline has mEventId then pass editedMEvent else pass mEvent to openViewSource
+function handleOpenViewSource(mEvent, roomTimeline) {
+  const eventId = mEvent.getId();
+  const { editedTimeline } = roomTimeline ?? {};
+  let editedMEvent;
+  if (editedTimeline?.has(eventId)) {
+    const editedList = editedTimeline.get(eventId);
+    editedMEvent = editedList[editedList.length - 1];
+  }
+  openViewSource(editedMEvent !== undefined ? editedMEvent : mEvent);
+}
+
 const MessageOptions = React.memo(({
   roomTimeline, mEvent, edit, reply,
 }) => {
@@ -516,7 +528,7 @@ const MessageOptions = React.memo(({
             </MenuItem>
             <MenuItem
               iconSrc={CmdIC}
-              onClick={() => openViewSource(mEvent)}
+              onClick={() => handleOpenViewSource(mEvent, roomTimeline)}
             >
               View source
             </MenuItem>


### PR DESCRIPTION
Signed-off-by: Clament John <cj@hackerlab.in>

fixes #376 

<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

### Description

When we click view source for an edited message we were showing the original event (the unedited event) instead of the latest edited event.

#### Type of change
- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings





<!-- Replace -->
Preview: https://6230529cace91206d67467a0--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
