### PR TITLE
Reduce dependence on third-party build scripts in release pipeline

### DIFF
--- a/.github/workflows/deploy-pull-request.yml
+++ b/.github/workflows/deploy-pull-request.yml
@@ -6,6 +6,9 @@ on:
         - completed
 jobs:
   get-build-and-deploy:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     if: >
       ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/netlify-dev.yml
+++ b/.github/workflows/netlify-dev.yml
@@ -9,7 +9,8 @@ jobs:
   deploy-to-netlify:
     name: 'Deploy'
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.0.0

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -29,6 +29,8 @@ jobs:
   deploy-to-netlify:
     name: 'Deploy to Netlify'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.0.0
@@ -45,6 +47,8 @@ jobs:
   push_to_dockerhub:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.0.0

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -5,13 +5,34 @@ on:
     types: [published]
 
 jobs:
+  create-release:
+    name: 'Create release tar'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3.0.0
+      - name: Build
+        run: |
+          npm ci
+          npm run build
+      - name: Get version from tag
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: Create tar.gz
+        run: tar -czvf cinny-${{ steps.vars.outputs.tag }}.tar.gz dist
+      - name: Upload release build
+        uses: actions/upload-artifact@v3.0.0
+        with:
+          name: cinny-${{ steps.vars.outputs.tag }}.tar.gz
+          path: cinny-${{ steps.vars.outputs.tag }}.tar.gz
+
   deploy-to-netlify:
     name: 'Deploy to Netlify'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.0.0
-      - name: Build and deploy to Netlify
+      - name: Deploy to Netlify
         uses: jsmrcaga/action-netlify-deploy@v1.7.2
         with:
           install_command: "npm ci"
@@ -20,16 +41,6 @@ jobs:
           BUILD_DIRECTORY: "dist"
           NETLIFY_DEPLOY_MESSAGE: "Prod deploy v${{ github.ref }}"
           NETLIFY_DEPLOY_TO_PROD: true
-      - name: Get version from tag
-        id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - name: Create tar.gz
-        run: tar -czvf cinny-${{ steps.vars.outputs.tag }}.tar.gz dist
-      - name: Upload tagged release
-        uses: softprops/action-gh-release@v0.1.14
-        with:
-          files: |
-            cinny-${{ steps.vars.outputs.tag }}.tar.gz
 
   push_to_dockerhub:
     name: Push Docker image to Docker Hub


### PR DESCRIPTION
This removes two third-party build scripts from the release
pipeline for the release tar.gz and limits the GITHUB_TOKEN permissions for other runs.

You can see a sample run of this at https://github.com/TheBlueMatt/cinny/actions/runs/1996755382 (which is just this PR plus a commit to run the release build on push) it only fails when it goes to do the actual upload, but generates the artifact no problem.

Obviously this will require a slight tweak to the release process, instead of releases being auto-uploaded after tagging, they'll have to be downloaded and uploaded manually, of course that will be required to address # #392 anyway, so its not all that much additional work. If that's a blocker, I can look into the GitHub API for release artifacts.