### PR TITLE
Fix inconsistent « Welcome to Empty room room » bug on room creation

### DIFF
--- a/src/app/organisms/room/RoomViewContent.jsx
+++ b/src/app/organisms/room/RoomViewContent.jsx
@@ -199,7 +199,7 @@ function usePaginate(
     };
     roomTimeline.on(cons.events.roomTimeline.PAGINATED, handlePaginatedFromServer);
     return () => {
-      roomTimeline.on(cons.events.roomTimeline.PAGINATED, handlePaginatedFromServer);
+      roomTimeline.removeListener(cons.events.roomTimeline.PAGINATED, handlePaginatedFromServer);
     };
   }, [roomTimeline]);
 

--- a/src/app/organisms/room/RoomViewContent.jsx
+++ b/src/app/organisms/room/RoomViewContent.jsx
@@ -411,7 +411,6 @@ function RoomViewContent({ eventId, roomTimeline }) {
 
     roomTimeline.on(cons.events.roomTimeline.SCROLL_TO_LIVE, handleScrollToLive);
     return () => {
-      if (timelineSVRef.current === null) return;
       roomTimeline.removeListener(cons.events.roomTimeline.SCROLL_TO_LIVE, handleScrollToLive);
     };
   }, [timelineInfo]);

--- a/src/app/organisms/room/RoomViewContent.jsx
+++ b/src/app/organisms/room/RoomViewContent.jsx
@@ -350,6 +350,8 @@ function useEventArrive(roomTimeline, readUptoEvtStore, timelineScrollRef, event
 let jumpToItemIndex = -1;
 
 function RoomViewContent({ eventId, roomTimeline }) {
+  const [, forceUpdate] = useForceUpdate();
+
   const [throttle] = useState(new Throttle());
 
   const timelineSVRef = useRef(null);
@@ -438,6 +440,19 @@ function RoomViewContent({ eventId, roomTimeline }) {
       timelineScroll.tryRestoringScroll();
     }
   }, [newEvent]);
+
+  useEffect(() => {
+    const { roomList } = initMatrix;
+    const handleProfileUpdate = () => {
+      console.log('%cRoom profile updated, rerendering', 'color: red;');
+      forceUpdate();
+    };
+
+    roomList.on(cons.events.roomList.ROOM_PROFILE_UPDATED, handleProfileUpdate);
+    return () => {
+      roomList.removeListener(cons.events.roomList.ROOM_PROFILE_UPDATED, handleProfileUpdate);
+    };
+  }, []);
 
   const handleTimelineScroll = (event) => {
     const timelineScroll = timelineScrollRef.current;

--- a/src/app/organisms/room/RoomViewContent.jsx
+++ b/src/app/organisms/room/RoomViewContent.jsx
@@ -55,15 +55,19 @@ function genRoomIntro(mEvent, roomTimeline) {
   const roomTopic = roomTimeline.room.currentState.getStateEvents('m.room.topic')[0]?.getContent().topic;
   const isDM = initMatrix.roomList.directs.has(roomTimeline.roomId);
   let avatarSrc = roomTimeline.room.getAvatarUrl(mx.baseUrl, 80, 80, 'crop');
-  avatarSrc = isDM ? roomTimeline.room.getAvatarFallbackMember()?.getAvatarUrl(mx.baseUrl, 80, 80, 'crop') : avatarSrc;
+  avatarSrc = isDM ? roomTimeline.room.getAvatarFallbackMember()
+    ?.getAvatarUrl(mx.baseUrl, 80, 80, 'crop') : avatarSrc;
+  const descPrefix = isDM
+    ? 'This is the beginning of your conversation with @'
+    : 'This is the beginning of ';
   return (
     <RoomIntro
       key={mEvent ? mEvent.getId() : 'room-intro'}
       roomId={roomTimeline.roomId}
       avatarSrc={avatarSrc}
       name={roomTimeline.room.name}
-      heading={`Welcome to ${roomTimeline.room.name}`}
-      desc={`This is the beginning of ${roomTimeline.room.name} room.${typeof roomTopic !== 'undefined' ? (` Topic: ${roomTopic}`) : ''}`}
+      heading={isDM ? roomTimeline.room.name : `Welcome to ${roomTimeline.room.name}`}
+      desc={`${descPrefix}${roomTimeline.room.name}.${typeof roomTopic !== 'undefined' ? (` Topic: ${roomTopic}`) : ''}`}
       time={mEvent ? `Created at ${dateFormat(mEvent.getDate(), 'dd mmmm yyyy, hh:MM TT')}` : null}
     />
   );


### PR DESCRIPTION
### Description
Fixes #430 
When creating a room, the welcome message will sometimes mention « Welcome to Empty room room », this pull request try to fix that
The « Empty room » name seems to come from the home server, the problem does not appear in the RoomViewHeader component because the component is subscribed to `cons.events.roomList.ROOM_PROFILE_UPDATED`and update the name of the room

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

### Notes
This is work in progress
I used the same technique to re-render than in RoomViewHeader but I think I created unnecessary re-renders
The data flow of this part of the app may need to be modified ?