### PR TITLE
Fix docker check to only run on Dockerfile change

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -32,8 +32,3 @@ jobs:
           name: pr.json
           path: pr.json
           retention-days: 1
-      - name: Build Docker image
-        uses: docker/build-push-action@v2.10.0
-        with:
-          context: .
-          push: false

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -1,0 +1,20 @@
+name: 'Docker check'
+
+on:
+  pull_request:
+    paths: 
+      - 'Dockerfile'
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{github.event.number}}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.0.0
+      - name: Build Docker image
+        uses: docker/build-push-action@v2.10.0
+        with:
+          context: .
+          push: false


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

### Description
Right now docker check are being run on every PR and this unnecessary makes times little longer. In this PR check will only run when someone change Dockerfile.
