### PR TITLE
Increase Pull request limit for dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
       day: "tuesday"
       time: "01:00"
       timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 5
 
   - package-ecosystem: docker
     directory: /
@@ -26,3 +27,4 @@ updates:
       day: "tuesday"
       time: "01:00"
       timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,16 @@
 # Docs: <https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/customizing-dependency-updates>
 
 version: 2
-
 updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: "tuesday"
+      time: "01:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 15
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -12,14 +20,6 @@ updates:
       timezone: "Asia/Kolkata"
 
   - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
-      day: "tuesday"
-      time: "01:00"
-      timezone: "Asia/Kolkata"
-
-  - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

### Description
Right now dependabot can only open 5 PR for npm dependency update, but they fall short when there are already some PR pending for review or blocked for any reason, so I have made the limit to 15 (3 times than what we had).


<!-- Replace -->
Preview: https://62454319610a70709720d981--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
