### PR TITLE
Fix max power level in room permissions

### DIFF
--- a/src/app/molecules/room-permissions/RoomPermissions.jsx
+++ b/src/app/molecules/room-permissions/RoomPermissions.jsx
@@ -179,6 +179,7 @@ function RoomPermissions({ roomId }) {
   const pLEvent = room.currentState.getStateEvents('m.room.power_levels')[0];
   const permissions = pLEvent.getContent();
   const canChangePermission = room.currentState.maySendStateEvent('m.room.power_levels', mx.getUserId());
+  const myPowerLevel = room.getMember(mx.getUserId())?.powerLevel || 100;
 
   const handlePowerSelector = (e, permKey, parentKey, powerLevel) => {
     const handlePowerLevelChange = (newPowerLevel) => {
@@ -208,7 +209,7 @@ function RoomPermissions({ roomId }) {
       (closeMenu) => (
         <PowerLevelSelector
           value={powerLevel}
-          max={100}
+          max={myPowerLevel}
           onSelect={(pl) => {
             closeMenu();
             handlePowerLevelChange(pl);

--- a/src/app/molecules/room-permissions/RoomPermissions.jsx
+++ b/src/app/molecules/room-permissions/RoomPermissions.jsx
@@ -179,7 +179,7 @@ function RoomPermissions({ roomId }) {
   const pLEvent = room.currentState.getStateEvents('m.room.power_levels')[0];
   const permissions = pLEvent.getContent();
   const canChangePermission = room.currentState.maySendStateEvent('m.room.power_levels', mx.getUserId());
-  const myPowerLevel = room.getMember(mx.getUserId())?.powerLevel || 100;
+  const myPowerLevel = room.getMember(mx.getUserId())?.powerLevel ?? 100;
 
   const handlePowerSelector = (e, permKey, parentKey, powerLevel) => {
     const handlePowerLevelChange = (newPowerLevel) => {


### PR DESCRIPTION
### Description
Fix allowed value of power level in room permissions, earlier the max value was 100 even if room members have power level more than 100.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings





<!-- Replace -->
Preview: https://62544fef87aa0d00685dcef6--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
