### PR TITLE
Replace forked action with original one

### DIFF
--- a/.github/workflows/deploy-pull-request.yml
+++ b/.github/workflows/deploy-pull-request.yml
@@ -68,7 +68,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE3_ID }}
         timeout-minutes: 1
       - name: Edit PR Description
-        uses: velas/pr-description@v1.0.1
+        uses: Beakyn/gha-comment-pull-request@v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
The reason to replace is that previous action fails when pull request content is empty and Beakyn/gha-comment-pull-request@v1.0.2 fixed this.

<!-- Replace -->
Preview: https://625f72d00d896f23f4f8f371--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
