### PR TITLE
Show devices without encryption support separately from unverified session

### DIFF
--- a/src/app/organisms/navigation/SideBar.jsx
+++ b/src/app/organisms/navigation/SideBar.jsx
@@ -92,7 +92,7 @@ function ProfileAvatarMenu() {
 
 function CrossSigninAlert() {
   const deviceList = useDeviceList();
-  const unverified = deviceList?.filter((device) => !isCrossVerified(device.device_id));
+  const unverified = deviceList?.filter((device) => isCrossVerified(device.device_id) === false);
 
   if (!unverified?.length) return null;
 

--- a/src/app/organisms/settings/DeviceManage.jsx
+++ b/src/app/organisms/settings/DeviceManage.jsx
@@ -124,9 +124,16 @@ function DeviceManage() {
 
   const unverified = [];
   const verified = [];
+  const noEncryption = [];
   deviceList.sort((a, b) => b.last_seen_ts - a.last_seen_ts).forEach((device) => {
-    if (isCrossVerified(device.device_id)) verified.push(device);
-    else unverified.push(device);
+    const isVerified = isCrossVerified(device.device_id);
+    if (isVerified === true) {
+      verified.push(device);
+    } else if (isVerified === false) {
+      unverified.push(device);
+    } else {
+      noEncryption.push(device);
+    }
   });
   return (
     <div className="device-manage">
@@ -148,6 +155,12 @@ function DeviceManage() {
             : <Text className="device-manage__info">No unverified session</Text>
         }
       </div>
+      {noEncryption.length > 0 && (
+      <div>
+        <MenuHeader>Sessions without encryption support</MenuHeader>
+        {noEncryption.map((device) => renderDevice(device, false))}
+      </div>
+      )}
       <div>
         <MenuHeader>Verified sessions</MenuHeader>
         {

--- a/src/app/organisms/settings/DeviceManage.jsx
+++ b/src/app/organisms/settings/DeviceManage.jsx
@@ -152,7 +152,7 @@ function DeviceManage() {
         {
           unverified.length > 0
             ? unverified.map((device) => renderDevice(device, false))
-            : <Text className="device-manage__info">No unverified session</Text>
+            : <Text className="device-manage__info">No unverified sessions</Text>
         }
       </div>
       {noEncryption.length > 0 && (

--- a/src/app/organisms/settings/DeviceManage.jsx
+++ b/src/app/organisms/settings/DeviceManage.jsx
@@ -158,7 +158,7 @@ function DeviceManage() {
       {noEncryption.length > 0 && (
       <div>
         <MenuHeader>Sessions without encryption support</MenuHeader>
-        {noEncryption.map((device) => renderDevice(device, false))}
+        {noEncryption.map((device) => renderDevice(device, true))}
       </div>
       )}
       <div>

--- a/src/util/matrixUtil.js
+++ b/src/util/matrixUtil.js
@@ -171,7 +171,8 @@ export function isCrossVerified(deviceId) {
     const deviceTrust = crossSignInfo.checkDeviceTrust(crossSignInfo, deviceInfo, false, true);
     return deviceTrust.isCrossSigningVerified();
   } catch {
-    return false;
+    // device does not support encryption
+    return null;
   }
 }
 


### PR DESCRIPTION
### Description

Cinny marks devices without encryption support as not verified. They however are unable to be verified. The warning is therefore not very useful (as there is no way to fix it, and the device not having access to encrypted messages to begin with).

Element Web also does this
![image](https://user-images.githubusercontent.com/35173023/164985117-a61f7dbf-b248-4323-99cb-471eade774d3.png)

This also makes these devices not appear in the "unverified sessions" warning in the navigation bar.

Before:
![image](https://user-images.githubusercontent.com/35173023/164984828-6617035f-a821-43c1-a57a-e1b91ffa3733.png)

After:
![image](https://user-images.githubusercontent.com/35173023/164985102-2f9fcd33-45cc-45b3-9864-7b69fb2933cd.png)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings








<!-- Replace -->
Preview: https://62657afdcc0e5743464f5e2c--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
