### PR TITLE
Add allowCustomHomeservers config option

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
     "kde.org",
     "matrix.org",
     "chat.mozilla.org"
-  ]
+  ],
+  "allowCustomHomeservers": true
 }

--- a/src/app/templates/auth/Auth.jsx
+++ b/src/app/templates/auth/Auth.jsx
@@ -93,12 +93,13 @@ function Homeserver({ onChange }) {
       const result = await (await fetch(configFileUrl, { method: 'GET' })).json();
       const selectedHs = result?.defaultHomeserver;
       const hsList = result?.homeserverList;
+      const allowCustom = result?.allowCustomHomeservers ?? true;
       if (!hsList?.length > 0 || selectedHs < 0 || selectedHs >= hsList?.length) {
         throw new Error();
       }
-      setHs({ selected: hsList[selectedHs], list: hsList });
+      setHs({ selected: hsList[selectedHs], list: hsList, allowCustom: allowCustom });
     } catch {
-      setHs({ selected: 'matrix.org', list: ['matrix.org'] });
+      setHs({ selected: 'matrix.org', list: ['matrix.org'], allowCustom: true });
     }
   }, []);
 
@@ -113,7 +114,8 @@ function Homeserver({ onChange }) {
   return (
     <>
       <div className="homeserver-form">
-        <Input name="homeserver" onChange={handleHsInput} value={hs?.selected} forwardRef={hsRef} label="Homeserver" />
+        <Input name="homeserver" onChange={handleHsInput} value={hs?.selected} forwardRef={hsRef} label="Homeserver"
+          disabled={hs === null || !hs.allowCustom} />
         <ContextMenu
           placement="right"
           content={(hideMenu) => (

--- a/src/app/templates/auth/Auth.jsx
+++ b/src/app/templates/auth/Auth.jsx
@@ -107,7 +107,7 @@ function Homeserver({ onChange }) {
     const { value } = e.target;
     setProcess({ isLoading: false });
     debounce._(async () => {
-      setHs({ selected: value.trim(), list: hs.list });
+      setHs({ ...hs, selected: value.trim() });
     }, 700)();
   };
 
@@ -128,7 +128,7 @@ function Homeserver({ onChange }) {
                     onClick={() => {
                       hideMenu();
                       hsRef.current.value = hsName;
-                      setHs({ selected: hsName, list: hs.list });
+                      setHs({ ...hs, selected: hsName });
                     }}
                   >
                     {hsName}


### PR DESCRIPTION
### Description

This adds a configuration option called `allowCustomHomeservers`, which prevents the Homeserver field on the login and register screens from being edited manually, only from the dropdown menu to the side. This is the same as the [`disable_custom_urls`](https://github.com/vector-im/element-web/blob/develop/docs/config.md#homeserver-configuration) option for Element.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings





<!-- Replace -->
Preview: https://627930c80bdcec21a5a79ffa--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
