### PR TITLE
Reduce third-party build script dependencies and reduce GITHUB_TOKEN perms in CI

### DIFF
--- a/.github/workflows/deploy-pull-request.yml
+++ b/.github/workflows/deploy-pull-request.yml
@@ -6,6 +6,9 @@ on:
         - completed
 jobs:
   get-build-and-deploy:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     if: >
       ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/netlify-dev.yml
+++ b/.github/workflows/netlify-dev.yml
@@ -9,7 +9,8 @@ jobs:
   deploy-to-netlify:
     name: 'Deploy'
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.0.2

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -37,6 +37,8 @@ jobs:
   deploy-to-netlify:
     name: 'Deploy to Netlify'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.0.2
@@ -53,6 +55,8 @@ jobs:
   push_to_dockerhub:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.0.2

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -21,12 +21,15 @@ jobs:
       - name: Create tar.gz
         run: tar -czvf cinny-${{ steps.vars.outputs.tag }}.tar.gz dist
       - name: Sign tar.gz
-        uses: actionhippie/gpgsign@4e28208b142cae93e1582401dcda1cf79e4f72c0
-        with:
-          private_key: ${{ secrets.GNUPG_KEY }}
-          passphrase: ${{ secrets.GNUPG_PASSPHRASE }}
-          detach_sign: true
-          files: cinny-${{ steps.vars.outputs.tag }}.tar.gz
+        run: |
+          echo '${{ secrets.GNUPG_KEY }}' | gpg --batch --import
+          # Sadly a few lines in the private key match a few lines in the public key,
+          # As a result just --export --armor gives us a few lines replaced with ***
+          # making it useless for importing the signing key. Instead, we dump it as
+          # non-armored and hex-encode it so that its printable.
+          echo "PGP Signing key, in raw PGP format in hex. Import with cat ... | xxd -r -p - | gpg --import"
+          gpg --export | xxd -p
+          echo '${{ secrets.GNUPG_PASSPHRASE }}' | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --armor --detach-sign cinny-${{ steps.vars.outputs.tag }}.tar.gz
       - name: Upload tagged release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         with:

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -5,21 +5,16 @@ on:
     types: [published]
 
 jobs:
-  deploy-to-netlify:
-    name: 'Deploy to Netlify'
+  create-release:
+    name: 'Create release tar'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Check out the repo
         uses: actions/checkout@v3.0.2
-      - name: Build and deploy to Netlify
-        uses: jsmrcaga/action-netlify-deploy@fb6a5f936a4b06a8f7793e69fc5a022ffe39807a
-        with:
-          install_command: "npm ci"
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          BUILD_DIRECTORY: "dist"
-          NETLIFY_DEPLOY_MESSAGE: "Prod deploy v${{ github.ref }}"
-          NETLIFY_DEPLOY_TO_PROD: true
+      - name: Build
+        run: |
+          npm ci
+          npm run build
       - name: Get version from tag
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
@@ -38,6 +33,22 @@ jobs:
           files: |
             cinny-${{ steps.vars.outputs.tag }}.tar.gz
             cinny-${{ steps.vars.outputs.tag }}.tar.gz.asc
+
+  deploy-to-netlify:
+    name: 'Deploy to Netlify'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3.0.2
+      - name: Build and deploy to Netlify
+        uses: jsmrcaga/action-netlify-deploy@fb6a5f936a4b06a8f7793e69fc5a022ffe39807a
+        with:
+          install_command: "npm ci"
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          BUILD_DIRECTORY: "dist"
+          NETLIFY_DEPLOY_MESSAGE: "Prod deploy v${{ github.ref }}"
+          NETLIFY_DEPLOY_TO_PROD: true
 
   push_to_dockerhub:
     name: Push Docker image to Docker Hub


### PR DESCRIPTION
This is a rebase of #394 after #498.

This removes the gpgsign action from the release pipeline as even pinned it fetches a docker container overlay which is applied for the duration of the build from an untrusted source. It also removes the `action-netlify-deploy` script from the TCB for the tar build, as the two build pipelines are separated into separate runs. Finally, it limits the GITHUB_TOKEN permissions for other runs.

As a bonus, it also prints the PGP (public) key used to sign the releases in CI, because I couldn't find the public key which signed the releases easily.

You can see a sample run of this at https://github.com/TheBlueMatt/cinny/actions/runs/2302106998 (which is just this PR plus a commit to run the release build on push) it only fails when it goes to do the actual upload, but generates the artifact no problem.



<!-- Replace -->
Preview: https://628f8418815b25701c7056ed--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
