### PR TITLE
Add the ability to focus on paste

### DIFF
--- a/src/client/event/hotkeys.js
+++ b/src/client/event/hotkeys.js
@@ -3,53 +3,90 @@ import navigation from '../state/navigation';
 import { markAsRead } from '../action/notifications';
 
 function listenKeyboard(event) {
-  // Ctrl/Cmd +
-  if (event.ctrlKey || event.metaKey) {
-    // k - for search Modal
-    if (event.keyCode === 75) {
-      event.preventDefault();
-      if (navigation.isRawModalVisible) return;
-      openSearch();
-    }
-  }
+	// Ctrl/Cmd +
+	if (event.ctrlKey || event.metaKey) {
+		// search modal
+		if (event.code === 'KeyK') {
+			event.preventDefault();
+			if (navigation.isRawModalVisible) {
+				return;
+			}
+			openSearch();
+		}
 
-  if (!event.ctrlKey && !event.altKey) {
-    if (navigation.isRawModalVisible) return;
-    if (['text', 'textarea'].includes(document.activeElement.type)) {
-      return;
-    }
+		// focus message field on paste
+		if (event.code === 'KeyV') {
+			const msgTextarea = document.getElementById('message-textarea');
+			msgTextarea?.focus();
+		}
+	}
 
-    // esc
-    if (event.keyCode === 27) {
-      if (navigation.isRoomSettings) {
-        toggleRoomSettings();
-        return;
-      }
-      if (navigation.selectedRoomId) {
-        markAsRead(navigation.selectedRoomId);
-        return;
-      }
-    }
+	if (!event.ctrlKey && !event.altKey && !event.metaKey) {
+		if (navigation.isRawModalVisible) return;
+		if (['text', 'textarea'].includes(document.activeElement.type)) {
+			return;
+		}
 
-    // Don't allow these keys to type/focus message field
-    if ((event.keyCode !== 8 && event.keyCode < 48)
-      || (event.keyCode >= 91 && event.keyCode <= 93)
-      || (event.keyCode >= 112 && event.keyCode <= 183)) {
-      return;
-    }
+		if (event.code === 'Escape') {
+			if (navigation.isRoomSettings) {
+				toggleRoomSettings();
+				return;
+			}
+			if (navigation.selectedRoomId) {
+				markAsRead(navigation.selectedRoomId);
+				return;
+			}
+		}
 
-    // press any key to focus and type in message field
-    const msgTextarea = document.getElementById('message-textarea');
-    msgTextarea?.focus();
-  }
+		// focus the text field on most keypresses
+		if (shouldFocusMessageField(event.code)) {
+			// press any key to focus and type in message field
+			const msgTextarea = document.getElementById('message-textarea');
+			msgTextarea?.focus();
+		}
+	}
+}
+
+function shouldFocusMessageField(code) {
+
+	// should focus on alphanumeric values, and backspace
+	if (code.startsWith('Key')) {
+		return true;
+	}
+	if (code.startsWith('Digit')) {
+		return true;
+	}
+	if (code === 'Backspace') {
+		return true;
+	}
+
+	// do not focus if super key is pressed
+	if (code.startsWith('Meta')) { // chrome
+		return false;
+	}
+	if (code.startsWith('OS')) { // firefox
+		return false;
+	}
+
+	// do not focus on F keys
+	if (/^F\d+$/.test(code)) {
+		return false;
+	}
+
+	// do not focus on numlock/scroll lock
+	if (code === 'NumLock' || code === 'ScrollLock') {
+		return false;
+	}
+
+	return true;
 }
 
 function initHotkeys() {
-  document.body.addEventListener('keydown', listenKeyboard);
+	document.body.addEventListener('keydown', listenKeyboard);
 }
 
 function removeHotkeys() {
-  document.body.removeEventListener('keydown', listenKeyboard);
+	document.body.removeEventListener('keydown', listenKeyboard);
 }
 
 export { initHotkeys, removeHotkeys };

--- a/src/client/event/hotkeys.js
+++ b/src/client/event/hotkeys.js
@@ -2,91 +2,90 @@ import { openSearch, toggleRoomSettings } from '../action/navigation';
 import navigation from '../state/navigation';
 import { markAsRead } from '../action/notifications';
 
-function listenKeyboard(event) {
-	// Ctrl/Cmd +
-	if (event.ctrlKey || event.metaKey) {
-		// search modal
-		if (event.code === 'KeyK') {
-			event.preventDefault();
-			if (navigation.isRawModalVisible) {
-				return;
-			}
-			openSearch();
-		}
+function shouldFocusMessageField(code) {
+  // should focus on alphanumeric values, and backspace
+  if (code.startsWith('Key')) {
+    return true;
+  }
+  if (code.startsWith('Digit')) {
+    return true;
+  }
+  if (code === 'Backspace') {
+    return true;
+  }
 
-		// focus message field on paste
-		if (event.code === 'KeyV') {
-			const msgTextarea = document.getElementById('message-textarea');
-			msgTextarea?.focus();
-		}
-	}
+  // do not focus if super key is pressed
+  if (code.startsWith('Meta')) { // chrome
+    return false;
+  }
+  if (code.startsWith('OS')) { // firefox
+    return false;
+  }
 
-	if (!event.ctrlKey && !event.altKey && !event.metaKey) {
-		if (navigation.isRawModalVisible) return;
-		if (['text', 'textarea'].includes(document.activeElement.type)) {
-			return;
-		}
+  // do not focus on F keys
+  if (/^F\d+$/.test(code)) {
+    return false;
+  }
 
-		if (event.code === 'Escape') {
-			if (navigation.isRoomSettings) {
-				toggleRoomSettings();
-				return;
-			}
-			if (navigation.selectedRoomId) {
-				markAsRead(navigation.selectedRoomId);
-				return;
-			}
-		}
+  // do not focus on numlock/scroll lock
+  if (code === 'NumLock' || code === 'ScrollLock') {
+    return false;
+  }
 
-		// focus the text field on most keypresses
-		if (shouldFocusMessageField(event.code)) {
-			// press any key to focus and type in message field
-			const msgTextarea = document.getElementById('message-textarea');
-			msgTextarea?.focus();
-		}
-	}
+  return true;
 }
 
-function shouldFocusMessageField(code) {
+function listenKeyboard(event) {
+  // Ctrl/Cmd +
+  if (event.ctrlKey || event.metaKey) {
+    // search modal
+    if (event.code === 'KeyK') {
+      event.preventDefault();
+      if (navigation.isRawModalVisible) {
+        return;
+      }
+      openSearch();
+    }
 
-	// should focus on alphanumeric values, and backspace
-	if (code.startsWith('Key')) {
-		return true;
-	}
-	if (code.startsWith('Digit')) {
-		return true;
-	}
-	if (code === 'Backspace') {
-		return true;
-	}
+    // focus message field on paste
+    if (event.code === 'KeyV') {
+      const msgTextarea = document.getElementById('message-textarea');
+      msgTextarea?.focus();
+    }
+  }
 
-	// do not focus if super key is pressed
-	if (code.startsWith('Meta')) { // chrome
-		return false;
-	}
-	if (code.startsWith('OS')) { // firefox
-		return false;
-	}
+  if (!event.ctrlKey && !event.altKey && !event.metaKey) {
+    if (navigation.isRawModalVisible) return;
+    if (['text', 'textarea'].includes(document.activeElement.type)) {
+      return;
+    }
 
-	// do not focus on F keys
-	if (/^F\d+$/.test(code)) {
-		return false;
-	}
+    if (event.code === 'Escape') {
+      if (navigation.isRoomSettings) {
+        toggleRoomSettings();
+        return;
+      }
+      if (navigation.selectedRoomId) {
+        markAsRead(navigation.selectedRoomId);
+        return;
+      }
+    }
 
-	// do not focus on numlock/scroll lock
-	if (code === 'NumLock' || code === 'ScrollLock') {
-		return false;
-	}
-
-	return true;
+    // focus the text field on most keypresses
+    if (shouldFocusMessageField(event.code)) {
+      // press any key to focus and type in message field
+      const msgTextarea = document.getElementById('message-textarea');
+      msgTextarea?.focus();
+    }
+  }
 }
 
 function initHotkeys() {
-	document.body.addEventListener('keydown', listenKeyboard);
+  document.body.addEventListener('keydown', listenKeyboard);
 }
 
 function removeHotkeys() {
-	document.body.removeEventListener('keydown', listenKeyboard);
+  document.body.removeEventListener('keydown', listenKeyboard);
 }
 
 export { initHotkeys, removeHotkeys };

--- a/src/client/event/hotkeys.js
+++ b/src/client/event/hotkeys.js
@@ -2,6 +2,7 @@ import { openSearch, toggleRoomSettings } from '../action/navigation';
 import navigation from '../state/navigation';
 import { markAsRead } from '../action/notifications';
 
+// describes which keys should auto-focus the message field
 function shouldFocusMessageField(code) {
   // should focus on alphanumeric values, and backspace
   if (code.startsWith('Key')) {
@@ -38,7 +39,7 @@ function shouldFocusMessageField(code) {
 function listenKeyboard(event) {
   // Ctrl/Cmd +
   if (event.ctrlKey || event.metaKey) {
-    // search modal
+    // open search modal
     if (event.code === 'KeyK') {
       event.preventDefault();
       if (navigation.isRawModalVisible) {


### PR DESCRIPTION
Also refactored a small amount to use KeyEvent.code instead of KeyEvent.keyCode, which is deprecated.

<!-- Please read https://github.com/ajbura/cinny/CONTRIBUTING.md before submitting your pull request -->

### Description

When in a room or DM, pasting does nothing if you are not focused in the message field. Probably better to have listed this (in #544) as a bug instead of a feature request, but wanted to be safe. I have also updated the code to use `KeyEvent.code` instead of `KeyEvent.keyCode`. The latter is deprecated, code resulting from it is harder to read, and is platform-specific (even if it is agreed-upon for the most part).

Fixes #544

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- Replace -->
Preview: https://627ceecf7dcce60084d25618--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
