### PR TITLE
Add emoji name fallback

### DIFF
--- a/src/app/organisms/emoji-board/emoji.js
+++ b/src/app/organisms/emoji-board/emoji.js
@@ -1,5 +1,6 @@
 import emojisData from 'emojibase-data/en/compact.json';
-import shortcodes from 'emojibase-data/en/shortcodes/joypixels.json';
+import joypixels from 'emojibase-data/en/shortcodes/joypixels.json';
+import emojibase from 'emojibase-data/en/shortcodes/emojibase.json';
 
 const emojiGroups = [{
   name: 'Smileys & people',
@@ -52,7 +53,7 @@ function addToGroup(emoji) {
 
 const emojis = [];
 emojisData.forEach((emoji) => {
-  const myShortCodes = shortcodes[emoji.hexcode];
+  const myShortCodes = joypixels[emoji.hexcode] || emojibase[emoji.hexcode];
   if (!myShortCodes) return;
   const em = {
     ...emoji,


### PR DESCRIPTION
### Description

Allow to use emojis that not have a joypixels name yet. An example of this is 🫠 (the melting face emoji; new in unicode 14). This fix allows it to show up as `:melt:` in the emoji picker.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- Replace -->
Preview: https://62bb3785467ee50c2f09f6fa--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
