### PR TITLE
Fix parsing encoded matrix.to URL

### DIFF
--- a/src/util/sanitize.js
+++ b/src/util/sanitize.js
@@ -44,7 +44,7 @@ function transformSpanTag(tagName, attribs) {
 }
 
 function transformATag(tagName, attribs) {
-  const userLink = attribs.href.match(/^https?:\/\/matrix.to\/#\/(@.+:.+)/);
+  const userLink = decodeURIComponent(attribs.href).match(/^https?:\/\/matrix.to\/#\/(@.+:.+)/);
   if (userLink !== null) {
     // convert user link to pill
     const userId = userLink[1];


### PR DESCRIPTION
### Description

Fix parsing percent encoded mention link, e.g. `https://matrix.to/#/%40alice%3Aexample.org`.

From https://spec.matrix.org/v1.3/appendices/#matrixto-navigation:

> The components of the matrix.to URI (<identifier> and <extra parameter>) are to be percent-encoded as per RFC 3986.
>
> Historically, clients have not produced URIs which are fully encoded. Clients should try to interpret these cases to the best of their ability. For example, an unencoded room alias should still work within the client if possible

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- Replace -->
Preview: https://62be974c1173561b66ffc7ee--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
