### PR TITLE
Perform ESC check before "ignore keybinds while focusing on inputs" check

### DIFF
--- a/src/client/event/hotkeys.js
+++ b/src/client/event/hotkeys.js
@@ -51,9 +51,6 @@ function listenKeyboard(event) {
 
   if (!event.ctrlKey && !event.altKey && !event.metaKey) {
     if (navigation.isRawModalVisible) return;
-    if (['input', 'textarea'].includes(document.activeElement.tagName.toLowerCase())) {
-      return;
-    }
 
     if (event.code === 'Escape') {
       if (navigation.isRoomSettings) {
@@ -64,6 +61,10 @@ function listenKeyboard(event) {
         markAsRead(navigation.selectedRoomId);
         return;
       }
+    }
+
+    if (['input', 'textarea'].includes(document.activeElement.tagName.toLowerCase())) {
+      return;
     }
 
     // focus the text field on most keypresses


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Bug fix - allows you to press ESC to mark the current room as read while you are focused on the message text box


Fixes #668 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- Replace -->
Preview: https://62ca6efe368e15032be224c5--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
