### PR TITLE
Blurhash support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-autosize-textarea": "^7.1.0",
+        "react-blurhash": "^0.1.3",
         "react-dnd": "^15.1.2",
         "react-dnd-html5-backend": "^15.1.3",
         "react-dom": "^17.0.2",
@@ -11550,6 +11551,15 @@
         "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/react-blurhash": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/react-blurhash/-/react-blurhash-0.1.3.tgz",
+      "integrity": "sha512-Q9lqbXg92NU6/2DoIl/cBM8YWL+Z4X66OiG4aT9ozOgjBwx104LHFCH5stf6aF+s0Q9Wf310Ul+dG+VXJltmPg==",
+      "peerDependencies": {
+        "blurhash": "^1.1.1",
+        "react": ">=15"
+      }
+    },
     "node_modules/react-dnd": {
       "version": "15.1.2",
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-15.1.2.tgz",
@@ -22948,6 +22958,12 @@
         "line-height": "^0.3.1",
         "prop-types": "^15.5.6"
       }
+    },
+    "react-blurhash": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/react-blurhash/-/react-blurhash-0.1.3.tgz",
+      "integrity": "sha512-Q9lqbXg92NU6/2DoIl/cBM8YWL+Z4X66OiG4aT9ozOgjBwx104LHFCH5stf6aF+s0Q9Wf310Ul+dG+VXJltmPg==",
+      "requires": {}
     },
     "react-dnd": {
       "version": "15.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
         "@tippyjs/react": "^4.2.6",
         "babel-polyfill": "^6.26.0",
+        "blurhash": "^1.1.5",
         "browser-encrypt-attachment": "^0.3.0",
         "dateformat": "^5.0.3",
         "emojibase-data": "^7.0.1",
@@ -3014,6 +3015,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
       "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -3029,7 +3032,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -3557,6 +3562,11 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "node_modules/blurhash": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-1.1.5.tgz",
+      "integrity": "sha512-a+LO3A2DfxTaTztsmkbLYmUzUeApi0LZuKalwbNmqAHR6HhJGMt1qSV/R3wc+w4DL28holjqO3Bg74aUGavGjg=="
     },
     "node_modules/bmp-js": {
       "version": "0.1.0",
@@ -16495,15 +16505,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
           "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -16515,7 +16524,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -16949,6 +16960,11 @@
           "dev": true
         }
       }
+    },
+    "blurhash": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-1.1.5.tgz",
+      "integrity": "sha512-a+LO3A2DfxTaTztsmkbLYmUzUeApi0LZuKalwbNmqAHR6HhJGMt1qSV/R3wc+w4DL28holjqO3Bg74aUGavGjg=="
     },
     "bmp-js": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-autosize-textarea": "^7.1.0",
+    "react-blurhash": "^0.1.3",
     "react-dnd": "^15.1.2",
     "react-dnd-html5-backend": "^15.1.3",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
     "@tippyjs/react": "^4.2.6",
     "babel-polyfill": "^6.26.0",
+    "blurhash": "^1.1.5",
     "browser-encrypt-attachment": "^0.3.0",
     "dateformat": "^5.0.3",
     "emojibase-data": "^7.0.1",

--- a/src/app/molecules/media/Media.jsx
+++ b/src/app/molecules/media/Media.jsx
@@ -4,6 +4,7 @@ import './Media.scss';
 
 import encrypt from 'browser-encrypt-attachment';
 
+import { BlurhashCanvas } from 'react-blurhash';
 import Text from '../../atoms/text/Text';
 import IconButton from '../../atoms/button/IconButton';
 import Spinner from '../../atoms/spinner/Spinner';
@@ -155,9 +156,10 @@ File.propTypes = {
 };
 
 function Image({
-  name, width, height, link, file, type,
+  name, width, height, link, file, type, blurhash,
 }) {
   const [url, setUrl] = useState(null);
+  const [loaded, setLoaded] = useState();
 
   useEffect(() => {
     let unmounted = false;
@@ -176,7 +178,8 @@ function Image({
     <div className="file-container">
       <FileHeader name={name} link={url || link} type={type} external />
       <div style={{ height: width !== null ? getNativeHeight(width, height) : 'unset' }} className="image-container">
-        { url !== null && <img src={url || link} alt={name} />}
+        {blurhash && <BlurhashCanvas hash={blurhash} punch={1} style={{ display: loaded && 'none' }} />}
+        {url !== null && <img src={url || link} alt={name} onLoad={() => setLoaded(true)} style={{ display: !loaded && 'none' }} />}
       </div>
     </div>
   );
@@ -186,6 +189,7 @@ Image.defaultProps = {
   width: null,
   height: null,
   type: '',
+  blurhash: '',
 };
 Image.propTypes = {
   name: PropTypes.string.isRequired,
@@ -194,6 +198,7 @@ Image.propTypes = {
   link: PropTypes.string.isRequired,
   file: PropTypes.shape({}),
   type: PropTypes.string,
+  blurhash: PropTypes.string,
 };
 
 function Audio({

--- a/src/app/molecules/media/Media.jsx
+++ b/src/app/molecules/media/Media.jsx
@@ -159,7 +159,6 @@ function Image({
   name, width, height, link, file, type, blurhash,
 }) {
   const [url, setUrl] = useState(null);
-  const [loaded, setLoaded] = useState();
 
   useEffect(() => {
     let unmounted = false;
@@ -178,8 +177,8 @@ function Image({
     <div className="file-container">
       <FileHeader name={name} link={url || link} type={type} external />
       <div style={{ height: width !== null ? getNativeHeight(width, height) : 'unset' }} className="image-container">
-        {blurhash && <BlurhashCanvas hash={blurhash} punch={1} style={{ display: loaded && 'none' }} />}
-        {url !== null && <img src={url || link} alt={name} onLoad={() => setLoaded(true)} style={{ display: !loaded && 'none' }} />}
+        {blurhash && <BlurhashCanvas hash={blurhash} punch={1} />}
+        {url !== null && <img src={url || link} alt={name} />}
       </div>
     </div>
   );

--- a/src/app/molecules/media/Media.jsx
+++ b/src/app/molecules/media/Media.jsx
@@ -177,8 +177,8 @@ function Image({
     <div className="file-container">
       <FileHeader name={name} link={url || link} type={type} external />
       <div style={{ height: width !== null ? getNativeHeight(width, height) : 'unset' }} className="image-container">
-        {blurhash && <BlurhashCanvas hash={blurhash} punch={1} />}
-        {url !== null && <img src={url || link} alt={name} />}
+        { blurhash && <BlurhashCanvas hash={blurhash} punch={1} />}
+        { url !== null && <img src={url || link} alt={name} />}
       </div>
     </div>
   );
@@ -244,8 +244,8 @@ Audio.propTypes = {
 };
 
 function Video({
-  name, link, thumbnail,
-  width, height, file, type, thumbnailFile, thumbnailType,
+  name, link, thumbnail, thumbnailFile, thumbnailType,
+  width, height, file, type, blurhash,
 }) {
   const [isLoading, setIsLoading] = useState(false);
   const [url, setUrl] = useState(null);
@@ -281,10 +281,11 @@ function Video({
       <div
         style={{
           height: width !== null ? getNativeHeight(width, height) : 'unset',
-          backgroundImage: thumbUrl === null ? 'none' : `url(${thumbUrl}`,
         }}
         className="video-container"
       >
+        { url === null && blurhash && <BlurhashCanvas hash={blurhash} punch={1} />}
+        { url === null && thumbUrl !== null && <img src={thumbUrl} />}
         { url === null && isLoading && <Spinner size="small" /> }
         { url === null && !isLoading && <IconButton onClick={handlePlayVideo} tooltip="Play video" src={PlaySVG} />}
         { url !== null && (
@@ -302,20 +303,22 @@ Video.defaultProps = {
   height: null,
   file: null,
   thumbnail: null,
-  type: '',
   thumbnailType: null,
   thumbnailFile: null,
+  type: '',
+  blurhash: null,
 };
 Video.propTypes = {
   name: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
   thumbnail: PropTypes.string,
+  thumbnailFile: PropTypes.shape({}),
+  thumbnailType: PropTypes.string,
   width: PropTypes.number,
   height: PropTypes.number,
   file: PropTypes.shape({}),
   type: PropTypes.string,
-  thumbnailFile: PropTypes.shape({}),
-  thumbnailType: PropTypes.string,
+  blurhash: PropTypes.string,
 };
 
 export {

--- a/src/app/molecules/media/Media.jsx
+++ b/src/app/molecules/media/Media.jsx
@@ -285,7 +285,10 @@ function Video({
         className="video-container"
       >
         { url === null && blurhash && <BlurhashCanvas hash={blurhash} punch={1} />}
-        { url === null && thumbUrl !== null && <img src={thumbUrl} />}
+        { url === null && thumbUrl !== null && (
+          /* eslint-disable-next-line jsx-a11y/alt-text */
+          <img src={thumbUrl} />
+        )}
         { url === null && isLoading && <Spinner size="small" /> }
         { url === null && !isLoading && <IconButton onClick={handlePlayVideo} tooltip="Play video" src={PlaySVG} />}
         { url !== null && (

--- a/src/app/molecules/media/Media.scss
+++ b/src/app/molecules/media/Media.scss
@@ -44,7 +44,8 @@
   background-size: cover;
 }
 
-.image-container {
+.image-container,
+.video-container {
   & img,
   & canvas {
     position: absolute;
@@ -59,6 +60,7 @@
 .video-container {
   & .ic-btn-surface {
     background-color: var(--bg-surface-low);
+    position: absolute;
   }
   video {
     width: 100%;

--- a/src/app/molecules/media/Media.scss
+++ b/src/app/molecules/media/Media.scss
@@ -33,6 +33,8 @@
   font-size: 0;
   line-height: 0;
 
+  position: relative;
+
   display: flex;
   justify-content: center;
   align-items: center;
@@ -45,6 +47,7 @@
 .image-container {
   & img,
   & canvas {
+    position: absolute;
     max-width: unset !important;
     width: 100% !important;
     border-radius: 0 !important;

--- a/src/app/molecules/media/Media.scss
+++ b/src/app/molecules/media/Media.scss
@@ -43,7 +43,8 @@
 }
 
 .image-container {
-  & img {
+  & img,
+  & canvas {
     max-width: unset !important;
     width: 100% !important;
     border-radius: 0 !important;
@@ -56,11 +57,11 @@
     background-color: var(--bg-surface-low);
   }
   video {
-    width: 100%
+    width: 100%;
   }
 }
 .audio-container {
   audio {
-    width: 100%
+    width: 100%;
   }
 }

--- a/src/app/molecules/media/Media.scss
+++ b/src/app/molecules/media/Media.scss
@@ -50,6 +50,7 @@
     position: absolute;
     max-width: unset !important;
     width: 100% !important;
+    height: 100%;
     border-radius: 0 !important;
     margin: 0 !important;
   }

--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -657,6 +657,7 @@ function genMediaContent(mE) {
           height={typeof mContent.info?.h === 'number' ? mContent.info?.h : null}
           file={isEncryptedFile ? mContent.file : null}
           type={mContent.info?.mimetype}
+          blurhash={blurhash}
         />
       );
     default:

--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -609,6 +609,8 @@ function genMediaContent(mE) {
   let msgType = mE.getContent()?.msgtype;
   if (mE.getType() === 'm.sticker') msgType = 'm.image';
 
+  const blurhash = mContent?.info?.['xyz.amorgan.blurhash'];
+
   switch (msgType) {
     case 'm.file':
       return (
@@ -628,6 +630,7 @@ function genMediaContent(mE) {
           link={mx.mxcUrlToHttp(mediaMXC)}
           file={isEncryptedFile ? mContent.file : null}
           type={mContent.info?.mimetype}
+          blurhash={blurhash}
         />
       );
     case 'm.audio':

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -3,23 +3,28 @@ import { micromark } from 'micromark';
 import { gfm, gfmHtml } from 'micromark-extension-gfm';
 import encrypt from 'browser-encrypt-attachment';
 import { math } from 'micromark-extension-math';
+import { encode } from 'blurhash';
 import { getShortcodeToEmoji } from '../../app/organisms/emoji-board/custom-emoji';
 import { mathExtensionHtml, spoilerExtension, spoilerExtensionHtml } from '../../util/markdown';
 import cons from './cons';
 import settings from './settings';
 
-function getImageDimension(file) {
-  return new Promise((resolve) => {
+const blurhashField = 'xyz.amorgan.blurhash';
+
+function encodeBlurhash(context) {
+  const data = context.getImageData(0, 0, context.canvas.width, context.canvas.height);
+  return encode(data.data, data.width, data.height, 4, 4);
+}
+
+function loadImage(url) {
+  return new Promise((resolve, reject) => {
     const img = new Image();
-    img.onload = async () => {
-      resolve({
-        w: img.width,
-        h: img.height,
-      });
-    };
-    img.src = URL.createObjectURL(file);
+    img.onload = () => resolve(img);
+    img.onerror = (err) => reject(err);
+    img.src = url;
   });
 }
+
 function loadVideo(videoFile) {
   return new Promise((resolve, reject) => {
     const video = document.createElement('video');
@@ -83,6 +88,7 @@ function getVideoThumbnail(video, width, height, mimeType) {
           h: targetHeight,
           mimetype: thumbnail.type,
           size: thumbnail.size,
+          [blurhashField]: encodeBlurhash(context),
         },
       });
     }, mimeType);
@@ -302,10 +308,17 @@ class RoomsInput extends EventEmitter {
     let uploadData = null;
 
     if (fileType === 'image') {
-      const imgDimension = await getImageDimension(file);
+      const img = await loadImage(URL.createObjectURL(file));
 
-      info.w = imgDimension.w;
-      info.h = imgDimension.h;
+      info.w = img.width;
+      info.h = img.height;
+
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const context = canvas.getContext('2d');
+      context.drawImage(img, 0, 0);
+      info[blurhashField] = encodeBlurhash(context);
 
       content.msgtype = 'm.image';
       content.body = file.name || 'Image';

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -11,8 +11,13 @@ import settings from './settings';
 
 const blurhashField = 'xyz.amorgan.blurhash';
 
-function encodeBlurhash(context) {
-  const data = context.getImageData(0, 0, context.canvas.width, context.canvas.height);
+function encodeBlurhash(img) {
+  const canvas = document.createElement('canvas');
+  canvas.width = 100;
+  canvas.height = 100;
+  const context = canvas.getContext('2d');
+  context.drawImage(img, 0, 0, canvas.width, canvas.height);
+  const data = context.getImageData(0, 0, canvas.width, canvas.height);
   return encode(data.data, data.width, data.height, 4, 4);
 }
 
@@ -88,7 +93,7 @@ function getVideoThumbnail(video, width, height, mimeType) {
           h: targetHeight,
           mimetype: thumbnail.type,
           size: thumbnail.size,
-          [blurhashField]: encodeBlurhash(context),
+          [blurhashField]: encodeBlurhash(video),
         },
       });
     }, mimeType);
@@ -313,12 +318,7 @@ class RoomsInput extends EventEmitter {
       info.w = img.width;
       info.h = img.height;
 
-      const canvas = document.createElement('canvas');
-      canvas.width = img.width;
-      canvas.height = img.height;
-      const context = canvas.getContext('2d');
-      context.drawImage(img, 0, 0);
-      info[blurhashField] = encodeBlurhash(context);
+      info[blurhashField] = encodeBlurhash(img);
 
       content.msgtype = 'm.image';
       content.body = file.name || 'Image';

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -93,7 +93,6 @@ function getVideoThumbnail(video, width, height, mimeType) {
           h: targetHeight,
           mimetype: thumbnail.type,
           size: thumbnail.size,
-          [blurhashField]: encodeBlurhash(video),
         },
       });
     }, mimeType);
@@ -317,7 +316,6 @@ class RoomsInput extends EventEmitter {
 
       info.w = img.width;
       info.h = img.height;
-
       info[blurhashField] = encodeBlurhash(img);
 
       content.msgtype = 'm.image';
@@ -328,8 +326,11 @@ class RoomsInput extends EventEmitter {
 
       try {
         const video = await loadVideo(file);
+
         info.w = video.videoWidth;
         info.h = video.videoHeight;
+        info[blurhashField] = encodeBlurhash(video);
+
         const thumbnailData = await getVideoThumbnail(video, video.videoWidth, video.videoHeight, 'image/jpeg');
         const thumbnailUploadData = await this.uploadFile(roomId, thumbnailData.thumbnail);
         info.thumbnail_info = thumbnailData.info;


### PR DESCRIPTION
### Description
Adds [blurhash](https://blurha.sh) support as for [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).

- [x] Sending
  - [x] Images
  - [x] Videos
- [x] Receiving
  - [x] Images
  - [x] Videos

https://user-images.githubusercontent.com/35173023/182788742-b7ef526d-813f-4fc2-b34f-1cffa3825ce4.mp4

(With "Good 3G" network throttle option)

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



















<!-- Replace -->
Preview: https://62ede4ef4739797ad4345d50--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
