### PR TITLE
Show full timestamp on hover

### DIFF
--- a/src/app/atoms/time/Time.jsx
+++ b/src/app/atoms/time/Time.jsx
@@ -4,29 +4,41 @@ import PropTypes from 'prop-types';
 import dateFormat from 'dateformat';
 import { isInSameDay } from '../../../util/common';
 
-function Time({ timestamp }) {
+function Time({ timestamp, fullTime }) {
   const date = new Date(timestamp);
 
-  const compareDate = new Date();
-  const isToday = isInSameDay(date, compareDate);
+  const formattedFullTime = dateFormat(date, 'dd mmmm yyyy, hh:MM TT');
+  let formattedDate = formattedFullTime;
 
-  compareDate.setDate(compareDate.getDate() - 1);
-  const isYesterday = isInSameDay(date, compareDate);
+  if (!fullTime) {
+    const compareDate = new Date();
+    const isToday = isInSameDay(date, compareDate);
+    compareDate.setDate(compareDate.getDate() - 1);
+    const isYesterday = isInSameDay(date, compareDate);
 
-  const formattedDate = dateFormat(date, isToday || isYesterday ? 'hh:MM TT' : 'dd/mm/yyyy');
+    formattedDate = dateFormat(date, isToday || isYesterday ? 'hh:MM TT' : 'dd/mm/yyyy');
+    if (isYesterday) {
+      formattedDate = `Yesterday, ${formattedDate}`;
+    }
+  }
 
   return (
     <time
       dateTime={date.toISOString()}
-      title={dateFormat(date, 'dd mmmm yyyy, hh:MM TT')}
+      title={formattedFullTime}
     >
-      {isYesterday ? `Yesterday, ${formattedDate}` : formattedDate}
+      {formattedDate}
     </time>
   );
 }
 
+Time.defaultProps = {
+  fullTime: false,
+};
+
 Time.propTypes = {
   timestamp: PropTypes.number.isRequired,
+  fullTime: PropTypes.bool,
 };
 
 export default Time;

--- a/src/app/atoms/time/Time.jsx
+++ b/src/app/atoms/time/Time.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import dateFormat from 'dateformat';
+
+function Time({ timestamp }) {
+  const date = new Date(timestamp);
+  return (
+    <time
+      dateTime={date.toISOString()}
+      title={dateFormat(date, 'dd mmmm yyyy, hh:MM TT')}
+    >
+      {dateFormat(date, 'hh:MM TT')}
+    </time>
+  );
+}
+
+Time.propTypes = {
+  timestamp: PropTypes.number.isRequired,
+};
+
+export default Time;

--- a/src/app/atoms/time/Time.jsx
+++ b/src/app/atoms/time/Time.jsx
@@ -2,15 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import dateFormat from 'dateformat';
+import { isInSameDay } from '../../../util/common';
 
 function Time({ timestamp }) {
   const date = new Date(timestamp);
+
+  const compareDate = new Date();
+  const isToday = isInSameDay(date, compareDate);
+
+  compareDate.setDate(compareDate.getDate() - 1);
+  const isYesterday = isInSameDay(date, compareDate);
+
+  const formattedDate = dateFormat(date, isToday || isYesterday ? 'hh:MM TT' : 'dd/mm/yyyy');
+
   return (
     <time
       dateTime={date.toISOString()}
       title={dateFormat(date, 'dd mmmm yyyy, hh:MM TT')}
     >
-      {dateFormat(date, 'hh:MM TT')}
+      {isYesterday ? `Yesterday, ${formattedDate}` : formattedDate}
     </time>
   );
 }

--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -69,7 +69,7 @@ const MessageAvatar = React.memo(({
 ));
 
 const MessageHeader = React.memo(({
-  userId, username, timestamp,
+  userId, username, timestamp, fullTime,
 }) => (
   <div className="message__header">
     <Text
@@ -84,15 +84,19 @@ const MessageHeader = React.memo(({
     </Text>
     <div className="message__time">
       <Text variant="b3">
-        <Time timestamp={timestamp} />
+        <Time timestamp={timestamp} fullTime={fullTime} />
       </Text>
     </div>
   </div>
 ));
+MessageHeader.defaultProps = {
+  fullTime: false,
+};
 MessageHeader.propTypes = {
   userId: PropTypes.string.isRequired,
   username: PropTypes.string.isRequired,
   timestamp: PropTypes.number.isRequired,
+  fullTime: PropTypes.bool,
 };
 
 function MessageReply({ name, color, body }) {
@@ -677,7 +681,7 @@ function getEditedBody(editedMEvent) {
 }
 
 function Message({
-  mEvent, isBodyOnly, roomTimeline, focus, timestamp,
+  mEvent, isBodyOnly, roomTimeline, focus, fullTime,
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const roomId = mEvent.getRoomId();
@@ -738,7 +742,12 @@ function Message({
       }
       <div className="message__main-container">
         {!isBodyOnly && (
-          <MessageHeader userId={senderId} username={username} timestamp={timestamp} />
+          <MessageHeader
+            userId={senderId}
+            username={username}
+            timestamp={mEvent.getTs()}
+            fullTime={fullTime}
+          />
         )}
         {roomTimeline && isReply && (
           <MessageReplyWrapper
@@ -786,13 +795,14 @@ Message.defaultProps = {
   isBodyOnly: false,
   focus: false,
   roomTimeline: null,
+  fullTime: false,
 };
 Message.propTypes = {
   mEvent: PropTypes.shape({}).isRequired,
   isBodyOnly: PropTypes.bool,
   roomTimeline: PropTypes.shape({}),
   focus: PropTypes.bool,
-  timestamp: PropTypes.number.isRequired,
+  fullTime: PropTypes.bool,
 };
 
 export { Message, MessageReply, PlaceholderMessage };

--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -25,6 +25,7 @@ import Tooltip from '../../atoms/tooltip/Tooltip';
 import Input from '../../atoms/input/Input';
 import Avatar from '../../atoms/avatar/Avatar';
 import IconButton from '../../atoms/button/IconButton';
+import Time from '../../atoms/time/Time';
 import ContextMenu, { MenuHeader, MenuItem, MenuBorder } from '../../atoms/context-menu/ContextMenu';
 import * as Media from '../media/Media';
 
@@ -68,7 +69,7 @@ const MessageAvatar = React.memo(({
 ));
 
 const MessageHeader = React.memo(({
-  userId, username, time,
+  userId, username, timestamp,
 }) => (
   <div className="message__header">
     <Text
@@ -82,14 +83,16 @@ const MessageHeader = React.memo(({
       <span>{twemojify(userId)}</span>
     </Text>
     <div className="message__time">
-      <Text variant="b3">{time}</Text>
+      <Text variant="b3">
+        <Time timestamp={timestamp} />
+      </Text>
     </div>
   </div>
 ));
 MessageHeader.propTypes = {
   userId: PropTypes.string.isRequired,
   username: PropTypes.string.isRequired,
-  time: PropTypes.string.isRequired,
+  timestamp: PropTypes.number.isRequired,
 };
 
 function MessageReply({ name, color, body }) {
@@ -674,7 +677,7 @@ function getEditedBody(editedMEvent) {
 }
 
 function Message({
-  mEvent, isBodyOnly, roomTimeline, focus, time,
+  mEvent, isBodyOnly, roomTimeline, focus, timestamp,
 }) {
   const [isEditing, setIsEditing] = useState(false);
   const roomId = mEvent.getRoomId();
@@ -735,7 +738,7 @@ function Message({
       }
       <div className="message__main-container">
         {!isBodyOnly && (
-          <MessageHeader userId={senderId} username={username} time={time} />
+          <MessageHeader userId={senderId} username={username} timestamp={timestamp} />
         )}
         {roomTimeline && isReply && (
           <MessageReplyWrapper
@@ -789,7 +792,7 @@ Message.propTypes = {
   isBodyOnly: PropTypes.bool,
   roomTimeline: PropTypes.shape({}),
   focus: PropTypes.bool,
-  time: PropTypes.string.isRequired,
+  timestamp: PropTypes.number.isRequired,
 };
 
 export { Message, MessageReply, PlaceholderMessage };

--- a/src/app/molecules/message/TimelineChange.jsx
+++ b/src/app/molecules/message/TimelineChange.jsx
@@ -4,6 +4,7 @@ import './TimelineChange.scss';
 
 import Text from '../../atoms/text/Text';
 import RawIcon from '../../atoms/system-icons/RawIcon';
+import Time from '../../atoms/time/Time';
 
 import JoinArraowIC from '../../../../public/res/ic/outlined/join-arrow.svg';
 import LeaveArraowIC from '../../../../public/res/ic/outlined/leave-arrow.svg';
@@ -12,7 +13,7 @@ import InviteCancelArraowIC from '../../../../public/res/ic/outlined/invite-canc
 import UserIC from '../../../../public/res/ic/outlined/user.svg';
 
 function TimelineChange({
-  variant, content, time, onClick,
+  variant, content, timestamp, onClick,
 }) {
   let iconSrc;
 
@@ -48,7 +49,9 @@ function TimelineChange({
         </Text>
       </div>
       <div className="timeline-change__time">
-        <Text variant="b3">{time}</Text>
+        <Text variant="b3">
+          <Time timestamp={timestamp} />
+        </Text>
       </div>
     </button>
   );
@@ -68,7 +71,7 @@ TimelineChange.propTypes = {
     PropTypes.string,
     PropTypes.node,
   ]).isRequired,
-  time: PropTypes.string.isRequired,
+  timestamp: PropTypes.number.isRequired,
   onClick: PropTypes.func,
 };
 

--- a/src/app/molecules/room-search/RoomSearch.jsx
+++ b/src/app/molecules/room-search/RoomSearch.jsx
@@ -120,14 +120,13 @@ function RoomSearch({ roomId }) {
   const renderTimeline = (timeline) => (
     <div className="room-search__result-item" key={timeline[0].getId()}>
       { timeline.map((mEvent) => {
-        const time = dateFormat(mEvent.getDate(), 'dd/mm/yyyy - hh:MM TT');
         const id = mEvent.getId();
         return (
           <React.Fragment key={id}>
             <Message
               mEvent={mEvent}
               isBodyOnly={false}
-              time={time}
+              fullTime
             />
             <Button onClick={() => selectRoom(roomId, id)}>View</Button>
           </React.Fragment>

--- a/src/app/organisms/room/RoomViewContent.jsx
+++ b/src/app/organisms/room/RoomViewContent.jsx
@@ -125,10 +125,7 @@ function renderEvent(roomTimeline, mEvent, prevMEvent, isFocus = false) {
     && prevMEvent.getType() !== 'm.room.create'
     && diffMinutes(mEvent.getDate(), prevMEvent.getDate()) <= MAX_MSG_DIFF_MINUTES
   );
-  const mDate = mEvent.getDate();
-  const isToday = isInSameDay(mDate, new Date());
-
-  const time = dateFormat(mDate, isToday ? 'hh:MM TT' : 'dd/mm/yyyy');
+  const timestamp = mEvent.getTs();
 
   if (mEvent.getType() === 'm.room.member') {
     const timelineChange = parseTimelineChange(mEvent);
@@ -138,7 +135,7 @@ function renderEvent(roomTimeline, mEvent, prevMEvent, isFocus = false) {
         key={mEvent.getId()}
         variant={timelineChange.variant}
         content={timelineChange.content}
-        time={time}
+        timestamp={timestamp}
       />
     );
   }
@@ -149,7 +146,7 @@ function renderEvent(roomTimeline, mEvent, prevMEvent, isFocus = false) {
       isBodyOnly={isBodyOnly}
       roomTimeline={roomTimeline}
       focus={isFocus}
-      time={time}
+      timestamp={timestamp}
     />
   );
 }

--- a/src/app/organisms/room/RoomViewContent.jsx
+++ b/src/app/organisms/room/RoomViewContent.jsx
@@ -146,7 +146,7 @@ function renderEvent(roomTimeline, mEvent, prevMEvent, isFocus = false) {
       isBodyOnly={isBodyOnly}
       roomTimeline={roomTimeline}
       focus={isFocus}
-      timestamp={timestamp}
+      fullTime={false}
     />
   );
 }


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Shows the full date when hovering over a time of a message or event. It also changes it to not be date anymore for past days as the date can now be found out by hovering over the time.

![image](https://user-images.githubusercontent.com/35173023/182962061-0a729d01-103f-4cf4-bb9a-705141e7f864.png)

Fixes #684

#### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings








<!-- Replace -->
Preview: https://62ed22314d1e7c6b09c6ffc4--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
