### PR TITLE
Add a button in the about screen to clear and reload the cache

### DIFF
--- a/src/app/organisms/settings/Settings.jsx
+++ b/src/app/organisms/settings/Settings.jsx
@@ -239,6 +239,7 @@ function AboutSection() {
             <div className="settings-about__btns">
               <Button onClick={() => window.open('https://github.com/ajbura/cinny')}>Source code</Button>
               <Button onClick={() => window.open('https://cinny.in/#sponsor')}>Support</Button>
+              <Button onClick={() => settings.clearCacheAndReload()} variant="danger">Clear cache & reload</Button>
             </div>
           </div>
         </div>

--- a/src/client/state/settings.js
+++ b/src/client/state/settings.js
@@ -147,6 +147,14 @@ class Settings extends EventEmitter {
     return settings.isNotificationSounds;
   }
 
+  clearCacheAndReload() {
+    const mx = initMatrix.matrixClient;
+    mx.stopClient()
+    mx.store.deleteAllData().then(() => {
+        window.location.reload();
+    });
+}
+
   setter(action) {
     const actions = {
       [cons.actions.settings.TOGGLE_SYSTEM_THEME]: () => {


### PR DESCRIPTION
### Description

The recent security issue in matrix-js-sdk can now be worked around by clearing the cache in element-web, this implements similar functionality in cinny, to avoid this bug without needing to log out. Also it's generally a useful thing when synapse acts up.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

Placement was just to show the proof of concept, feel free to edit it.

cherry-picked from v2.12 if you want it https://github.com/morguldir/cinny/pull/new/clear-cache-and-reload-2.1.3




<!-- Replace -->
Preview: https://793--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
