### PR TITLE
Allow rendering messages as plaintext

### DIFF
--- a/src/app/atoms/math/Math.jsx
+++ b/src/app/atoms/math/Math.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import './Math.scss';
 
 import katex from 'katex';
 import 'katex/dist/katex.min.css';

--- a/src/app/atoms/math/Math.scss
+++ b/src/app/atoms/math/Math.scss
@@ -1,0 +1,3 @@
+.katex-display {
+  margin: 0 !important;
+}

--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -729,23 +729,23 @@ function Message({
   let { body } = content;
   const username = mEvent.sender ? getUsernameOfRoomMember(mEvent.sender) : getUsername(senderId);
   const avatarSrc = mEvent.sender?.getAvatarUrl(initMatrix.matrixClient.baseUrl, 36, 36, 'crop') ?? null;
+  let isCustomHTML = content.format === 'org.matrix.custom.html';
+  let customHTML = isCustomHTML ? content.formatted_body : null;
 
   const edit = useCallback(() => {
     setEdit(eventId);
   }, []);
   const reply = useCallback(() => {
-    replyTo(senderId, mEvent.getId(), body);
-  }, [body]);
+    replyTo(senderId, mEvent.getId(), body, customHTML);
+  }, [body, customHTML]);
 
   if (msgType === 'm.emote') className.push('message--type-emote');
 
-  let isCustomHTML = content.format === 'org.matrix.custom.html';
   const isEdited = roomTimeline ? editedTimeline.has(eventId) : false;
   const haveReactions = roomTimeline
     ? reactionTimeline.has(eventId) || !!mEvent.getServerAggregatedRelation('m.annotation')
     : false;
   const isReply = !!mEvent.replyEventId;
-  let customHTML = isCustomHTML ? content.formatted_body : null;
 
   if (isEdited) {
     const editedList = editedTimeline.get(eventId);

--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -250,7 +250,7 @@ const MessageBody = React.memo(({
   if (!isCustomHTML) {
     // If this is a plaintext message, wrap it in a <p> element (automatically applying
     // white-space: pre-wrap) in order to preserve newlines
-    content = (<p>{content}</p>);
+    content = (<p className="message__body-plain">{content}</p>);
   }
 
   return (

--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -8,7 +8,9 @@ import './Message.scss';
 import { twemojify } from '../../../util/twemojify';
 
 import initMatrix from '../../../client/initMatrix';
-import { getUsername, getUsernameOfRoomMember, parseReply } from '../../../util/matrixUtil';
+import {
+  getUsername, getUsernameOfRoomMember, parseReply, trimHTMLReply,
+} from '../../../util/matrixUtil';
 import colorMXID from '../../../util/colorMXID';
 import { getEventCords } from '../../../util/common';
 import { redactEvent, sendReaction } from '../../../client/action/roomTimeline';
@@ -755,6 +757,7 @@ function Message({
 
   if (isReply) {
     body = parseReply(body)?.body ?? body;
+    customHTML = trimHTMLReply(customHTML);
   }
 
   if (typeof body !== 'string') body = '';

--- a/src/app/molecules/message/Message.scss
+++ b/src/app/molecules/message/Message.scss
@@ -174,8 +174,8 @@
     white-space: initial !important;
   }
 
-  & > .text > p:not(:last-child) {
-    margin-bottom: var(--sp-normal);
+  & > .text > p + p {
+    margin-top: var(--sp-normal);
   }
 
   & span[data-mx-pill] {

--- a/src/app/molecules/message/Message.scss
+++ b/src/app/molecules/message/Message.scss
@@ -163,7 +163,7 @@
 .message__body {
   word-break: break-word;
 
-  & > .text > * {
+  & > .text > .message__body-plain {
     white-space: pre-wrap;
   }
 

--- a/src/app/molecules/message/Message.scss
+++ b/src/app/molecules/message/Message.scss
@@ -174,7 +174,7 @@
     white-space: initial !important;
   }
 
-  & p:not(:last-child) {
+  & > .text > p:not(:last-child) {
     margin-bottom: var(--sp-normal);
   }
 

--- a/src/app/organisms/room/RoomViewInput.jsx
+++ b/src/app/organisms/room/RoomViewInput.jsx
@@ -143,9 +143,11 @@ function RoomViewInput({
     textAreaRef.current.focus();
   }
 
-  function setUpReply(userId, eventId, body) {
+  function setUpReply(userId, eventId, body, formattedBody) {
     setReplyTo({ userId, eventId, body });
-    roomsInput.setReplyTo(roomId, { userId, eventId, body });
+    roomsInput.setReplyTo(roomId, {
+      userId, eventId, body, formattedBody,
+    });
     focusInput();
   }
 

--- a/src/client/action/navigation.js
+++ b/src/client/action/navigation.js
@@ -139,12 +139,13 @@ export function openViewSource(event) {
   });
 }
 
-export function replyTo(userId, eventId, body) {
+export function replyTo(userId, eventId, body, formattedBody) {
   appDispatcher.dispatch({
     type: cons.actions.navigation.CLICK_REPLY_TO,
     userId,
     eventId,
     body,
+    formattedBody,
   });
 }
 

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -203,7 +203,7 @@ class RoomsInput extends EventEmitter {
 
     const content = {
       body: body.plain,
-      msgtype: msgType ?? 'm.text',
+      msgtype: msgType,
     };
 
     if (sanitizeText(body.plain) !== body.html || reply) {

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -6,11 +6,9 @@ import { getBlobSafeMimeType } from '../../util/mimetypes';
 import { sanitizeText } from '../../util/sanitize';
 import cons from './cons';
 import settings from './settings';
-import { htmlOutput, parser } from '../../util/markdown';
+import { markdown, plain } from '../../util/markdown';
 
 const blurhashField = 'xyz.amorgan.blurhash';
-const MXID_REGEX = /\B@\S+:\S+\.\S+[^.,:;?!\s]/g;
-const SHORTCODE_REGEX = /\B:([\w-]+):\B/g;
 
 function encodeBlurhash(img) {
   const canvas = document.createElement('canvas');
@@ -98,91 +96,6 @@ function getVideoThumbnail(video, width, height, mimeType) {
       });
     }, mimeType);
   });
-}
-
-function getFormattedBody(markdown) {
-  let content = parser(markdown);
-  if (content.length === 1 && content[0].type === 'paragraph') {
-    content = content[0].content;
-  }
-  return htmlOutput(content);
-}
-
-function getReplyFormattedBody(roomId, reply) {
-  const replyToLink = `<a href="https://matrix.to/#/${roomId}/${reply.eventId}">In reply to</a>`;
-  const userLink = `<a href="https://matrix.to/#/${reply.userId}">${reply.userId}</a>`;
-  const formattedReply = getFormattedBody(reply.body.replace(/\n/g, '\n> '));
-  return `<mx-reply><blockquote>${replyToLink}${userLink}<br />${formattedReply}</blockquote></mx-reply>`;
-}
-
-function bindReplyToContent(roomId, reply, content) {
-  const newContent = { ...content };
-  newContent.body = `> <${reply.userId}> ${reply.body.replace(/\n/g, '\n> ')}`;
-  newContent.body += `\n\n${content.body}`;
-  newContent.format = 'org.matrix.custom.html';
-  newContent['m.relates_to'] = content['m.relates_to'] || {};
-  newContent['m.relates_to']['m.in_reply_to'] = { event_id: reply.eventId };
-
-  const formattedReply = getReplyFormattedBody(roomId, reply);
-  newContent.formatted_body = formattedReply + (content.formatted_body || content.body);
-  return newContent;
-}
-
-function findAndReplace(text, regex, filter, replace) {
-  let copyText = text;
-  Array.from(copyText.matchAll(regex))
-    .filter(filter)
-    .reverse() /* to replace backward to forward */
-    .forEach((match) => {
-      const matchText = match[0];
-      const tag = replace(match);
-
-      copyText = copyText.substr(0, match.index)
-        + tag
-        + copyText.substr(match.index + matchText.length);
-    });
-  return copyText;
-}
-
-function formatUserPill(room, text) {
-  const { userIdsToDisplayNames } = room.currentState;
-  return findAndReplace(
-    text,
-    MXID_REGEX,
-    (match) => userIdsToDisplayNames[match[0]],
-    (match) => (
-      `<a href="https://matrix.to/#/${match[0]}">@${userIdsToDisplayNames[match[0]]}</a>`
-    ),
-  );
-}
-
-function formatEmoji(mx, room, roomList, text) {
-  const parentIds = roomList.getAllParentSpaces(room.roomId);
-  const parentRooms = [...parentIds].map((id) => mx.getRoom(id));
-  const allEmoji = getShortcodeToEmoji(mx, [room, ...parentRooms]);
-
-  return findAndReplace(
-    text,
-    SHORTCODE_REGEX,
-    (match) => allEmoji.has(match[1]),
-    (match) => {
-      const emoji = allEmoji.get(match[1]);
-
-      let tag;
-      if (emoji.mxc) {
-        tag = `<img data-mx-emoticon="" src="${
-          emoji.mxc
-        }" alt=":${
-          emoji.shortcode
-        }:" title=":${
-          emoji.shortcode
-        }:" height="32" />`;
-      } else {
-        tag = emoji.unicode;
-      }
-      return tag;
-    },
-  );
 }
 
 class RoomsInput extends EventEmitter {
@@ -274,9 +187,51 @@ class RoomsInput extends EventEmitter {
     return this.roomIdToInput.get(roomId)?.isSending || false;
   }
 
-  async sendInput(roomId, options) {
-    const { msgType, autoMarkdown } = options;
+  getContent(roomId, options, message, reply, edit) {
+    const msgType = options?.msgType || 'm.text';
+    const autoMarkdown = options?.autoMarkdown ?? true;
+
     const room = this.matrixClient.getRoom(roomId);
+
+    const userNames = room.currentState.userIdsToDisplayNames;
+    const parentIds = this.roomList.getAllParentSpaces(room.roomId);
+    const parentRooms = [...parentIds].map((id) => this.matrixClient.getRoom(id));
+    const emojis = getShortcodeToEmoji(this.matrixClient, [room, ...parentRooms]);
+
+    const output = settings.isMarkdown && autoMarkdown ? markdown : plain;
+    const body = output(message, { userNames, emojis });
+    console.debug(body);
+
+    const content = {
+      body: body.plain,
+      msgtype: msgType ?? 'm.text',
+    };
+
+    // formattedBody = formatEmoji(this.matrixClient, room, this.roomList, formattedBody);
+
+    if (sanitizeText(body.plain) !== body.html) {
+      content.format = 'org.matrix.custom.html';
+      content.formatted_body = body.html;
+    }
+
+    if (edit) {
+      content['m.new_content'] = { ...content };
+      content['m.relates_to'] = {
+        event_id: edit.getId(),
+        rel_type: 'm.replace',
+      };
+      content.body = ` * ${content.body}`;
+      if (content.formatted_body) content.formatted_body = ` * ${content.formatted_body}`;
+    }
+
+    if (reply) {
+      // TODO: Reply
+    }
+
+    return content;
+  }
+
+  async sendInput(roomId, options) {
     const input = this.getInput(roomId);
     input.isSending = true;
     this.roomIdToInput.set(roomId, input);
@@ -286,38 +241,7 @@ class RoomsInput extends EventEmitter {
     }
 
     if (this.getMessage(roomId).trim() !== '') {
-      const rawMessage = input.message;
-      let content = {
-        body: rawMessage,
-        msgtype: msgType ?? 'm.text',
-      };
-
-      // Apply formatting if relevant
-      let formattedBody = settings.isMarkdown && autoMarkdown
-        ? getFormattedBody(rawMessage)
-        : sanitizeText(rawMessage);
-
-      if (autoMarkdown) {
-        formattedBody = formatUserPill(room, formattedBody);
-        formattedBody = formatEmoji(this.matrixClient, room, this.roomList, formattedBody);
-
-        content.body = findAndReplace(
-          content.body,
-          MXID_REGEX,
-          (match) => room.currentState.userIdsToDisplayNames[match[0]],
-          (match) => `@${room.currentState.userIdsToDisplayNames[match[0]]}`,
-        );
-      }
-
-      if (formattedBody !== sanitizeText(rawMessage)) {
-        // Formatting was applied, and we need to switch to custom HTML
-        content.format = 'org.matrix.custom.html';
-        content.formatted_body = formattedBody;
-      }
-
-      if (typeof input.replyTo !== 'undefined') {
-        content = bindReplyToContent(roomId, input.replyTo, content);
-      }
+      const content = this.getContent(roomId, options, input.message, input.replyTo);
       this.matrixClient.sendMessage(roomId, content);
     }
 
@@ -460,55 +384,13 @@ class RoomsInput extends EventEmitter {
   }
 
   async sendEditedMessage(roomId, mEvent, editedBody) {
-    const room = this.matrixClient.getRoom(roomId);
-    const isReply = typeof mEvent.getWireContent()['m.relates_to']?.['m.in_reply_to'] !== 'undefined';
-
-    const msgtype = mEvent.getWireContent().msgtype ?? 'm.text';
-
-    const content = {
-      body: ` * ${editedBody}`,
-      msgtype,
-      'm.new_content': {
-        body: editedBody,
-        msgtype,
-      },
-      'm.relates_to': {
-        event_id: mEvent.getId(),
-        rel_type: 'm.replace',
-      },
-    };
-
-    // Apply formatting if relevant
-    let formattedBody = settings.isMarkdown
-      ? getFormattedBody(editedBody)
-      : sanitizeText(editedBody);
-    formattedBody = formatUserPill(room, formattedBody);
-    formattedBody = formatEmoji(this.matrixClient, room, this.roomList, formattedBody);
-
-    content.body = findAndReplace(
-      content.body,
-      MXID_REGEX,
-      (match) => room.currentState.userIdsToDisplayNames[match[0]],
-      (match) => `@${room.currentState.userIdsToDisplayNames[match[0]]}`,
+    const content = this.getContent(
+      roomId,
+      { msgType: mEvent.getWireContent().msgtype },
+      editedBody,
+      null,
+      mEvent,
     );
-    if (formattedBody !== sanitizeText(editedBody)) {
-      content.formatted_body = ` * ${formattedBody}`;
-      content.format = 'org.matrix.custom.html';
-      content['m.new_content'].formatted_body = formattedBody;
-      content['m.new_content'].format = 'org.matrix.custom.html';
-    }
-    if (isReply) {
-      const evBody = mEvent.getContent().body;
-      const replyHead = evBody.slice(0, evBody.indexOf('\n\n'));
-      const evFBody = mEvent.getContent().formatted_body;
-      const fReplyHead = evFBody.slice(0, evFBody.indexOf('</mx-reply>'));
-
-      content.format = 'org.matrix.custom.html';
-      content.formatted_body = `${fReplyHead}</mx-reply>${(content.formatted_body || content.body)}`;
-
-      content.body = `${replyHead}\n\n${content.body}`;
-    }
-
     this.matrixClient.sendMessage(roomId, content);
   }
 }

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -206,7 +206,7 @@ class RoomsInput extends EventEmitter {
       msgtype: msgType,
     };
 
-    if (sanitizeText(body.plain) !== body.html || reply) {
+    if (body.onlyPlain || reply) {
       content.format = 'org.matrix.custom.html';
       content.formatted_body = body.html;
     }

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -245,7 +245,7 @@ class RoomsInput extends EventEmitter {
         },
       };
 
-      content.body = `> <${reply.userId}> ${reply.body.replaceAll('\n', '\n> ')}\n\n${content.body}`;
+      content.body = `> <${reply.userId}> ${reply.body.replace(/\n/g, '\n> ')}\n\n${content.body}`;
 
       const replyToLink = `<a href="https://matrix.to/#/${encodeURIComponent(roomId)}/${encodeURIComponent(reply.eventId)}">In reply to</a>`;
       const userLink = `<a href="https://matrix.to/#/${encodeURIComponent(reply.userId)}">${sanitizeText(reply.userId)}</a>`;

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -206,7 +206,7 @@ class RoomsInput extends EventEmitter {
       msgtype: msgType,
     };
 
-    if (body.onlyPlain || reply) {
+    if (!body.onlyPlain || reply) {
       content.format = 'org.matrix.custom.html';
       content.formatted_body = body.html;
     }

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -200,7 +200,6 @@ class RoomsInput extends EventEmitter {
 
     const output = settings.isMarkdown && autoMarkdown ? markdown : plain;
     const body = output(message, { userNames, emojis });
-    console.debug(body);
 
     const content = {
       body: body.plain,

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -207,7 +207,7 @@ class RoomsInput extends EventEmitter {
       msgtype: msgType ?? 'm.text',
     };
 
-    if (sanitizeText(body.plain) !== body.html || reply?.formattedBody) {
+    if (sanitizeText(body.plain) !== body.html || reply) {
       content.format = 'org.matrix.custom.html';
       content.formatted_body = body.html;
     }
@@ -247,12 +247,11 @@ class RoomsInput extends EventEmitter {
       };
 
       content.body = `> <${reply.userId}> ${reply.body.replaceAll('\n', '\n> ')}\n\n${content.body}`;
-      if (reply.formattedBody) {
-        const replyToLink = `<a href="https://matrix.to/#/${roomId}/${reply.eventId}">In reply to</a>`;
-        const userLink = `<a href="https://matrix.to/#/${reply.userId}">${reply.userId}</a>`;
-        const fallback = `<mx-reply><blockquote>${replyToLink}${userLink}<br />${reply.formattedBody}</blockquote></mx-reply>`;
-        content.formatted_body = fallback + content.formatted_body;
-      }
+
+      const replyToLink = `<a href="https://matrix.to/#/${encodeURIComponent(roomId)}/${encodeURIComponent(reply.eventId)}">In reply to</a>`;
+      const userLink = `<a href="https://matrix.to/#/${encodeURIComponent(reply.userId)}">${sanitizeText(reply.userId)}</a>`;
+      const fallback = `<mx-reply><blockquote>${replyToLink}${userLink}<br />${reply.formattedBody || sanitizeText(reply.body)}</blockquote></mx-reply>`;
+      content.formatted_body = fallback + content.formatted_body;
     }
 
     return content;

--- a/src/client/state/navigation.js
+++ b/src/client/state/navigation.js
@@ -375,6 +375,7 @@ class Navigation extends EventEmitter {
           action.userId,
           action.eventId,
           action.body,
+          action.formattedBody,
         );
       },
       [cons.actions.navigation.OPEN_SEARCH]: () => {

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -8,18 +8,36 @@ function mathHtml(wrap, node) {
   return htmlTag(wrap, htmlTag('code', sanitizeText(node.content)), { 'data-mx-maths': node.content });
 }
 
-const rules = {
-  ...defaultRules,
+const plainRules = {
   Array: {
     ...defaultRules.Array,
     plain: (arr, output, state) => arr.map((node) => output(node, state)).join(''),
   },
-  displayMath: {
-    order: defaultRules.list.order + 0.5,
-    match: blockRegex(/^\$\$\n*([\s\S]+?)\n*\$\$/),
-    parse: (capture) => ({ content: capture[1] }),
-    plain: (node) => `$$\n${node.content}\n$$`,
-    html: (node) => mathHtml('div', node),
+  userMention: {
+    order: defaultRules.em.order - 0.9,
+    match: inlineRegex(/^(@\S+:\S+)/),
+    parse: (capture, _, state) => ({ content: `@${state.userNames[capture[1]]}`, id: capture[1] }),
+    plain: (node) => node.content,
+    html: (node) => htmlTag('a', sanitizeText(node.content), {
+      href: `https://matrix.to/#/${encodeURIComponent(node.id)}`,
+    }),
+  },
+  emoji: {
+    order: defaultRules.em.order - 0.1,
+    match: inlineRegex(/^:([\w-]+):/),
+    parse: (capture, _, state) => ({ content: capture[1], emoji: state.emojis.get(capture[1]) }),
+    plain: ({ emoji }) => (emoji.mxc
+      ? `:${emoji.shortcode}:`
+      : emoji.unicode),
+    html: ({ emoji }) => (emoji.mxc
+      ? htmlTag('img', null, {
+        'data-mx-emoticon': '',
+        src: emoji.mxc,
+        alt: `:${emoji.shortcode}:`,
+        title: `:${emoji.shortcode}:`,
+        height: 32,
+      }, false)
+      : emoji.unicode),
   },
   newline: {
     ...defaultRules.newline,
@@ -29,6 +47,28 @@ const rules = {
     ...defaultRules.paragraph,
     plain: (node, output, state) => `${output(node.content, state)}\n\n`,
     html: (node, output, state) => htmlTag('p', output(node.content, state)),
+  },
+  br: {
+    ...defaultRules.br,
+    match: anyScopeRegex(/^ *\n/),
+    plain: () => '\n',
+  },
+  text: {
+    ...defaultRules.text,
+    match: anyScopeRegex(/^[\s\S]+?(?=[^0-9A-Za-z\s\u00c0-\uffff]| *\n|\w+:\S|$)/),
+    plain: (node) => node.content,
+  },
+};
+
+const markdownRules = {
+  ...defaultRules,
+  ...plainRules,
+  displayMath: {
+    order: defaultRules.list.order + 0.5,
+    match: blockRegex(/^\$\$\n*([\s\S]+?)\n*\$\$/),
+    parse: (capture) => ({ content: capture[1] }),
+    plain: (node) => `$$\n${node.content}\n$$`,
+    html: (node) => mathHtml('div', node),
   },
   escape: {
     ...defaultRules.escape,
@@ -50,40 +90,58 @@ const rules = {
     ...defaultRules.del,
     plain: (node, output, state) => `~~${output(node.content, state)}~~`,
   },
+  inlineCode: {
+    ...defaultRules.inlineCode,
+    plain: (node, output, state) => `\`${output(node.content, state)}\``,
+  },
   spoiler: {
-    order: defaultRules.em.order - 0.5,
+    order: defaultRules.del.order + 0.1,
     match: inlineRegex(/^\|\|([\s\S]+?)\|\|(?:\(([\s\S]+?)\))?/),
     parse: (capture, parse, state) => ({
       content: parse(capture[1], state),
       reason: capture[2],
     }),
-    plain: (node) => `[spoiler${node.reason ? `: ${node.reason}` : ''}](mxc://somewhere)`,
-    html: (node, output, state) => `<span data-mx-spoiler${node.reason ? `="${sanitizeText(node.reason)}"` : ''}>${output(node.content, state)}</span>`,
+    // plain: (node) => `[spoiler${node.reason ? `: ${node.reason}` : ''}](mxc://somewhere)`,
+    html: (node, output, state) => htmlTag(
+      'span',
+      output(node.content, state),
+      { 'data-mx-spoiler': node.reason },
+    ),
   },
   inlineMath: {
-    order: defaultRules.del.order + 0.5,
+    order: defaultRules.del.order + 0.2,
     match: inlineRegex(/^\$(\S[\s\S]+?\S|\S)\$(?!\d)/),
     parse: (capture) => ({ content: capture[1] }),
     plain: (node) => `$${node.content}$`,
     html: (node) => mathHtml('span', node),
   },
-  br: {
-    ...defaultRules.br,
-    match: anyScopeRegex(/^ *\n/),
-    plain: () => '\n',
-  },
-  text: {
-    ...defaultRules.text,
-    match: anyScopeRegex(/^[\s\S]+?(?=[^0-9A-Za-z\s\u00c0-\uffff]| *\n|\w+:\S|$)/),
-    plain: (node) => node.content,
-  },
 };
 
-const parser = parserFor(rules);
+function genOut(rules) {
+  const parser = parserFor(rules);
 
-const plainOutput = outputFor(rules, 'plain');
-const htmlOutput = outputFor(rules, 'html');
+  const plain = outputFor(rules, 'plain');
+  const html = outputFor(rules, 'html');
 
-export {
-  parser, plainOutput, htmlOutput,
-};
+  return (source, state) => {
+    let content = parser(source, state);
+    if (content.length === 1 && content[0].type === 'paragraph') {
+      content = content[0].content;
+    }
+
+    let plainOut;
+    try {
+      plainOut = plain(content, state);
+    // eslint-disable-next-line no-empty
+    } catch (_) { }
+
+    return {
+      plain: plainOut || source,
+      // plain: plain(content, state),
+      html: html(content, state),
+    };
+  };
+}
+
+export const plain = genOut(plainRules);
+export const markdown = genOut(markdownRules);

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -84,6 +84,10 @@ const markdownRules = {
     ...defaultRules.codeBlock,
     plain: (node) => `\`\`\`${node.lang || ''}\n${node.content}\n\`\`\``,
   },
+  fence: {
+    ...defaultRules.fence,
+    match: blockRegex(/^ *(`{3,}|~{3,}) *(?:(\S+) *)?\n([\s\S]+?)\n?\1 *(?:\n *)*\n/),
+  },
   list: {
     ...defaultRules.list,
     plain: (node, output, state) => node.items.map((item, i) => {
@@ -93,7 +97,7 @@ const markdownRules = {
   },
   displayMath: {
     order: defaultRules.list.order + 0.5,
-    match: blockRegex(/^\$\$\n*([\s\S]+?)\n*\$\$/),
+    match: blockRegex(/^ *\$\$ *\n?([\s\S]+?)\n?\$\$ *(?:\n *)*\n/),
     parse: (capture) => ({ content: capture[1] }),
     plain: (node) => `$$\n${node.content}\n$$`,
     html: (node) => mathHtml('div', node),
@@ -137,7 +141,7 @@ const markdownRules = {
       content: parse(capture[1], state),
       reason: capture[2],
     }),
-    // plain: (node) => `[spoiler${node.reason ? `: ${node.reason}` : ''}](mxc://somewhere)`,
+    plain: (node, output, state) => `[spoiler${node.reason ? `: ${node.reason}` : ''}](${output(node.content, state)})`,
     html: (node, output, state) => htmlTag(
       'span',
       output(node.content, state),

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -22,6 +22,15 @@ const plainRules = {
       href: `https://matrix.to/#/${encodeURIComponent(node.id)}`,
     }),
   },
+  roomMention: {
+    order: defaultRules.em.order - 0.8,
+    match: inlineRegex(/^(#\S+:\S+)/), // TODO: Handle line beginning with roomMention (instead of heading)
+    parse: (capture) => ({ content: capture[1], id: capture[1] }),
+    plain: (node) => node.content,
+    html: (node) => htmlTag('a', sanitizeText(node.content), {
+      href: `https://matrix.to/#/${encodeURIComponent(node.id)}`,
+    }),
+  },
   emoji: {
     order: defaultRules.em.order - 0.1,
     match: inlineRegex(/^:([\w-]+):/),
@@ -73,7 +82,7 @@ const markdownRules = {
   },
   codeBlock: {
     ...defaultRules.codeBlock,
-    plain: (node) => `\`\`\`${node.lang}\n${node.content}\n\`\`\``,
+    plain: (node) => `\`\`\`${node.lang || ''}\n${node.content}\n\`\`\``,
   },
   list: {
     ...defaultRules.list,
@@ -152,6 +161,7 @@ function genOut(rules) {
 
   return (source, state) => {
     let content = parser(source, state);
+    console.debug(content);
     if (content.length === 1 && content[0].type === 'paragraph') {
       content = content[0].content;
     }

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -102,6 +102,11 @@ const markdownRules = {
     plain: (node) => `$$\n${node.content}\n$$`,
     html: (node) => mathHtml('div', node),
   },
+  shrug: {
+    order: defaultRules.escape.order - 0.5,
+    match: inlineRegex(/^¯\\_\(ツ\)_\/¯/),
+    parse: (capture) => ({ type: 'text', content: capture[0] }),
+  },
   escape: {
     ...defaultRules.escape,
     plain: (node, output, state) => `\\${output(node.content, state)}`,

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -93,16 +93,16 @@ const markdownRules = {
   heading: {
     ...defaultRules.heading,
     plain: (node, output, state) => {
-      const s = output(node.content, state);
+      const out = output(node.content, state);
       if (node.level <= 2) {
-        return `${s}\n${(node.level === 1 ? '=' : '-').repeat(s.length)}\n\n`;
+        return `${out}\n${(node.level === 1 ? '=' : '-').repeat(out.length)}\n\n`;
       }
-      return `${'#'.repeat(node.level)} ${s}\n\n`;
+      return `${'#'.repeat(node.level)} ${out}\n\n`;
     },
   },
   hr: {
     ...defaultRules.hr,
-    plain: () => '---',
+    plain: () => '---\n\n',
   },
   codeBlock: {
     ...defaultRules.codeBlock,
@@ -118,10 +118,10 @@ const markdownRules = {
   },
   list: {
     ...defaultRules.list,
-    plain: (node, output, state) => node.items.map((item, i) => {
+    plain: (node, output, state) => `${node.items.map((item, i) => {
       const prefix = node.ordered ? `${node.start + i + 1}. ` : '* ';
       return prefix + output(item, state).replaceAll('\n', `\n${' '.repeat(prefix.length)}`);
-    }).join('\n'),
+    }).join('\n')}\n`,
   },
   def: undefined,
   table: {
@@ -208,7 +208,14 @@ const markdownRules = {
   },
   link: {
     ...defaultRules.link,
-    plain: (node, output, state) => `[${output(node.content, state)}](${sanitizeUrl(node.target) || ''}${node.title ? ` "${node.title}"` : ''})`,
+    plain: (node, output, state) => {
+      const out = output(node.content, state);
+      const target = sanitizeUrl(node.target) || '';
+      if (out !== target || node.title) {
+        return `[${out}](${target}${node.title ? ` "${node.title}"` : ''})`;
+      }
+      return out;
+    },
     html: (node, output, state) => htmlTag('a', output(node.content, state), {
       href: sanitizeUrl(node.target) || '',
       title: node.title,
@@ -243,7 +250,7 @@ const markdownRules = {
   },
   inlineCode: {
     ...defaultRules.inlineCode,
-    plain: (node, output, state) => `\`${output(node.content, state)}\``,
+    plain: (node) => `\`${node.content}\``,
   },
   spoiler: {
     order: defaultRules.inlineCode.order + 0.1,

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -2,7 +2,7 @@ import SimpleMarkdown from '@khanacademy/simple-markdown';
 
 const {
   defaultRules, parserFor, outputFor, anyScopeRegex, blockRegex, inlineRegex,
-  sanitizeText, sanitizeUrl, parseRef,
+  sanitizeText, sanitizeUrl,
 } = SimpleMarkdown;
 
 function htmlTag(tagName, content, attributes, isClosed) {
@@ -109,6 +109,10 @@ const markdownRules = {
   fence: {
     ...defaultRules.fence,
     match: blockRegex(/^ *(`{3,}|~{3,}) *(?:(\S+) *)?\n([\s\S]+?)\n?\1 *(?:\n *)*\n/),
+  },
+  blockQuote: {
+    ...defaultRules.blockQuote,
+    plain: (node, output, state) => `> ${output(node.content, state).replaceAll('\n', '\n> ')}`,
   },
   list: {
     ...defaultRules.list,

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -287,18 +287,26 @@ const markdownRules = {
 function genOut(rules) {
   const parser = parserFor(rules);
 
-  const plain = outputFor(rules, 'plain');
-  const html = outputFor(rules, 'html');
+  const plainOut = outputFor(rules, 'plain');
+  const htmlOut = outputFor(rules, 'html');
 
   return (source, state) => {
     let content = parser(source, state);
+
     if (content.length === 1 && content[0].type === 'paragraph') {
       content = content[0].content;
     }
 
+    const plain = plainOut(content, state).trim();
+    const html = htmlOut(content, state);
+
+    const plainHtml = html.replaceAll('<br>', '\n').replaceAll('</p><p>', '\n\n').replace(/<\/?p>/g, '');
+    const onlyPlain = sanitizeText(plain) !== plainHtml;
+
     return {
-      plain: plain(content, state).trim(),
-      html: html(content, state),
+      onlyPlain,
+      plain,
+      html,
     };
   };
 }

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -238,7 +238,7 @@ function genOut(rules) {
     }
 
     return {
-      plain: plainOut.trim() || source,
+      plain: plainOut?.trim() || source,
       // plain: plain(content, state),
       html: html(content, state),
     };

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -92,7 +92,13 @@ const markdownRules = {
   ...plainRules,
   heading: {
     ...defaultRules.heading,
-    plain: (node, output, state) => `${'#'.repeat(node.level)} ${output(node.content, state)}`,
+    plain: (node, output, state) => {
+      const s = output(node.content, state);
+      if (node.level <= 2) {
+        return `${s}\n${(node.level === 1 ? '=' : '-').repeat(s.length)}\n\n`;
+      }
+      return `${'#'.repeat(node.level)} ${s}\n\n`;
+    },
   },
   hr: {
     ...defaultRules.hr,

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -114,7 +114,7 @@ const markdownRules = {
   },
   blockQuote: {
     ...defaultRules.blockQuote,
-    plain: (node, output, state) => `> ${output(node.content, state).replaceAll('\n', '\n> ')}`,
+    plain: (node, output, state) => `> ${output(node.content, state).trim().replaceAll('\n', '\n> ')}\n\n`,
   },
   list: {
     ...defaultRules.list,

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -145,11 +145,11 @@ const markdownRules = {
   image: {
     ...defaultRules.image,
     plain: (node) => `![${node.alt}](${sanitizeUrl(node.target) || ''}${node.title ? ` "${node.title}"` : ''})`,
-    html: (node, output, state) => htmlTag('img', output(node.content, state), {
+    html: (node) => htmlTag('img', '', {
       src: sanitizeUrl(node.target) || '',
       alt: node.alt,
       title: node.title,
-    }),
+    }, false),
   },
   reflink: undefined,
   refimage: undefined,

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -117,22 +117,29 @@ const markdownRules = {
       return prefix + output(item, state).replaceAll('\n', `\n${' '.repeat(prefix.length)}`);
     }).join('\n'),
   },
+  def: undefined,
+  table: {
+    ...defaultRules.table,
+  },
   displayMath: {
-    order: defaultRules.list.order + 0.5,
+    order: defaultRules.table.order + 0.1,
     match: blockRegex(/^ *\$\$ *\n?([\s\S]+?)\n?\$\$ *(?:\n *)*\n/),
     parse: (capture) => ({ content: capture[1] }),
     plain: (node) => `$$\n${node.content}\n$$`,
     html: (node) => mathHtml('div', node),
   },
-  def: undefined,
   shrug: {
-    order: defaultRules.escape.order - 0.5,
+    order: defaultRules.escape.order - 0.1,
     match: inlineRegex(/^¯\\_\(ツ\)_\/¯/),
     parse: (capture) => ({ type: 'text', content: capture[0] }),
   },
   escape: {
     ...defaultRules.escape,
     plain: (node, output, state) => `\\${output(node.content, state)}`,
+  },
+  tableSeparator: {
+    ...defaultRules.tableSeparator,
+    plain: () => ' | ',
   },
   link: {
     ...defaultRules.link,
@@ -174,7 +181,7 @@ const markdownRules = {
     plain: (node, output, state) => `\`${output(node.content, state)}\``,
   },
   spoiler: {
-    order: defaultRules.del.order + 0.1,
+    order: defaultRules.inlineCode.order + 0.1,
     match: inlineRegex(/^\|\|([\s\S]+?)\|\|(?:\(([\s\S]+?)\))?/),
     parse: (capture, parse, state) => ({
       content: parse(capture[1], state),
@@ -204,7 +211,6 @@ function genOut(rules) {
 
   return (source, state) => {
     let content = parser(source, state);
-    console.debug(content);
     if (content.length === 1 && content[0].type === 'paragraph') {
       content = content[0].content;
     }

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -26,10 +26,6 @@ function mathHtml(wrap, node) {
   return htmlTag(wrap, htmlTag('code', sanitizeText(node.content)), { 'data-mx-maths': node.content });
 }
 
-function normalizeRef(s) {
-  return s.replace(/\s+/g, ' ').toLowerCase().toUpperCase();
-}
-
 const plainRules = {
   Array: {
     ...defaultRules.Array,
@@ -128,14 +124,7 @@ const markdownRules = {
     plain: (node) => `$$\n${node.content}\n$$`,
     html: (node) => mathHtml('div', node),
   },
-  def: {
-    ...defaultRules.def,
-    parse: (capture, parse, state) => {
-      const c = [null, normalizeRef(capture[1]), capture[2], capture[3]];
-      return defaultRules.def.parse(c, parse, state);
-    },
-    plain: () => '',
-  },
+  def: undefined,
   shrug: {
     order: defaultRules.escape.order - 0.5,
     match: inlineRegex(/^¯\\_\(ツ\)_\/¯/),
@@ -162,22 +151,8 @@ const markdownRules = {
       title: node.title,
     }),
   },
-  reflink: {
-    ...defaultRules.reflink,
-    parse: (capture, parse, state) => defaultRules.reflink.parse(
-      [null, capture[1], normalizeRef(capture[2] || capture[1])],
-      parse,
-      state,
-    ),
-  },
-  refimage: {
-    ...defaultRules.refimage,
-    parse: (capture, parse, state) => defaultRules.refimage.parse(
-      [null, capture[1], normalizeRef(capture[2] || capture[1])],
-      parse,
-      state,
-    ),
-  },
+  reflink: undefined,
+  refimage: undefined,
   em: {
     ...defaultRules.em,
     plain: (node, output, state) => `_${output(node.content, state)}_`,

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -26,6 +26,8 @@ function mathHtml(wrap, node) {
   return htmlTag(wrap, htmlTag('code', sanitizeText(node.content)), { 'data-mx-maths': node.content });
 }
 
+const emojiRegex = /^:([\w-]+):/;
+
 const plainRules = {
   Array: {
     ...defaultRules.Array,
@@ -51,7 +53,14 @@ const plainRules = {
   },
   emoji: {
     order: defaultRules.em.order - 0.1,
-    match: inlineRegex(/^:([\w-]+):/),
+    match: (source, state) => {
+      if (!state.inline) return null;
+      const capture = emojiRegex.exec(source);
+      if (!capture) return null;
+      const emoji = state.emojis.get(capture[1]);
+      if (emoji) return capture;
+      return null;
+    },
     parse: (capture, _, state) => ({ content: capture[1], emoji: state.emojis.get(capture[1]) }),
     plain: ({ emoji }) => (emoji.mxc
       ? `:${emoji.shortcode}:`

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -36,7 +36,10 @@ const plainRules = {
   userMention: {
     order: defaultRules.em.order - 0.9,
     match: inlineRegex(/^(@\S+:\S+)/),
-    parse: (capture, _, state) => ({ content: `@${state.userNames[capture[1]]}`, id: capture[1] }),
+    parse: (capture, _, state) => ({
+      content: state.userNames[capture[1]] ? `@${state.userNames[capture[1]]}` : capture[1],
+      id: capture[1],
+    }),
     plain: (node) => node.content,
     html: (node) => htmlTag('a', sanitizeText(node.content), {
       href: `https://matrix.to/#/${encodeURIComponent(node.id)}`,

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -126,13 +126,13 @@ const markdownRules = {
   },
   blockQuote: {
     ...defaultRules.blockQuote,
-    plain: (node, output, state) => `> ${output(node.content, state).trim().replaceAll('\n', '\n> ')}\n\n`,
+    plain: (node, output, state) => `> ${output(node.content, state).trim().replace(/\n/g, '\n> ')}\n\n`,
   },
   list: {
     ...defaultRules.list,
     plain: (node, output, state) => `${node.items.map((item, i) => {
       const prefix = node.ordered ? `${node.start + i + 1}. ` : '* ';
-      return prefix + output(item, state).replaceAll('\n', `\n${' '.repeat(prefix.length)}`);
+      return prefix + output(item, state).replace(/\n/g, `\n${' '.repeat(prefix.length)}`);
     }).join('\n')}\n`,
   },
   def: undefined,
@@ -303,7 +303,7 @@ function genOut(rules) {
     const plain = plainOut(content, state).trim();
     const html = htmlOut(content, state);
 
-    const plainHtml = html.replaceAll('<br>', '\n').replaceAll('</p><p>', '\n\n').replace(/<\/?p>/g, '');
+    const plainHtml = html.replace(/<br>/g, '\n').replace(/<\/p><p>/g, '\n\n').replace(/<\/?p>/g, '');
     const onlyPlain = sanitizeText(plain) === plainHtml;
 
     return {

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -304,7 +304,7 @@ function genOut(rules) {
     const html = htmlOut(content, state);
 
     const plainHtml = html.replaceAll('<br>', '\n').replaceAll('</p><p>', '\n\n').replace(/<\/?p>/g, '');
-    const onlyPlain = sanitizeText(plain) !== plainHtml;
+    const onlyPlain = sanitizeText(plain) === plainHtml;
 
     return {
       onlyPlain,

--- a/src/util/matrixUtil.js
+++ b/src/util/matrixUtil.js
@@ -79,6 +79,15 @@ export function parseReply(rawBody) {
   };
 }
 
+export function trimHTMLReply(html) {
+  const suffix = '</mx-reply>';
+  const i = html.indexOf(suffix);
+  if (i < 0) {
+    return html;
+  }
+  return html.slice(i + suffix.length);
+}
+
 export function hasDMWith(userId) {
   const mx = initMatrix.matrixClient;
   const directIds = [...initMatrix.roomList.directs];

--- a/src/util/matrixUtil.js
+++ b/src/util/matrixUtil.js
@@ -80,6 +80,7 @@ export function parseReply(rawBody) {
 }
 
 export function trimHTMLReply(html) {
+  if (!html) return html;
   const suffix = '</mx-reply>';
   const i = html.indexOf(suffix);
   if (i < 0) {


### PR DESCRIPTION
### Description
This refactors the way sending messages (with edits and replies) is handled in `RoomsInput.js` and adds plaintext rendering of messages (plain and markdown). This allows for hiding spoilers in plain messages in the future. For now this moves mention and emoji to be parsing over to `simple-markdown`.

Fixes #770 
Fixes #746 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings



















































































<!-- Replace -->
Preview: https://805--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
