### PR TITLE
Ignore mimetype parameters in safety check

### DIFF
--- a/src/util/mimetypes.js
+++ b/src/util/mimetypes.js
@@ -26,12 +26,13 @@ export const ALLOWED_BLOB_MIMETYPES = [
 ];
 
 export function getBlobSafeMimeType(mimetype) {
-  if (!ALLOWED_BLOB_MIMETYPES.includes(mimetype)) {
+  const [type] = mimetype.split(';');
+  if (!ALLOWED_BLOB_MIMETYPES.includes(type)) {
     return 'application/octet-stream';
   }
   // Required for Chromium browsers
-  if (mimetype === 'video/quicktime') {
+  if (type === 'video/quicktime') {
     return 'video/mp4';
   }
-  return mimetype;
+  return type;
 }


### PR DESCRIPTION
### Description
This trims the mime type parameters off (`audio/ogg; codecs=opus` -> `audio/ogg`) before checking against the list of allowed types. Not doing this blocks some voice messages from playing for example.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings











<!-- Replace -->
Preview: https://631493a3e31c963d1c785482--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
