### PR TITLE
Handle messages with invalid body

### DIFF
--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -737,7 +737,6 @@ function Message({
     replyTo(senderId, mEvent.getId(), body);
   }, [body]);
 
-  if (body === undefined) return null;
   if (msgType === 'm.emote') className.push('message--type-emote');
 
   let isCustomHTML = content.format === 'org.matrix.custom.html';
@@ -752,12 +751,13 @@ function Message({
     const editedList = editedTimeline.get(eventId);
     const editedMEvent = editedList[editedList.length - 1];
     [body, isCustomHTML, customHTML] = getEditedBody(editedMEvent);
-    if (typeof body !== 'string') return null;
   }
 
   if (isReply) {
     body = parseReply(body)?.body ?? body;
   }
+
+  if (typeof body !== 'string') body = '';
 
   return (
     <div className={className.join(' ')}>


### PR DESCRIPTION
### Description
This displays messages with an invalid body as ones with an empty one mimicking elements behaviour. We might want to show the "Malformed event" message as we do with invalid media events.

Fixes #737

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- Replace -->
Preview: https://833--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
