### PR TITLE
Parsing HTML to Markdown AST

### DIFF
--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -803,7 +803,9 @@ function Message({
         )}
         {isEdit && (
           <MessageEdit
-            body={(customHTML ? html : plain)(customHTML || body, { kind: 'edit' }).plain}
+            body={(customHTML
+              ? html(customHTML, { kind: 'edit', onlyPlain: true }).plain
+              : plain(body, { kind: 'edit', onlyPlain: true }).plain)}
             onSave={(newBody) => {
               if (newBody !== body) {
                 initMatrix.roomsInput.sendEditedMessage(roomId, mEvent, newBody);

--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -40,6 +40,7 @@ import BinIC from '../../../../public/res/ic/outlined/bin.svg';
 
 import { confirmDialog } from '../confirm-dialog/ConfirmDialog';
 import { getBlobSafeMimeType } from '../../../util/mimetypes';
+import { html, plain } from '../../../util/markdown';
 
 function PlaceholderMessage() {
   return (
@@ -802,7 +803,7 @@ function Message({
         )}
         {isEdit && (
           <MessageEdit
-            body={body}
+            body={(customHTML ? html : plain)(customHTML || body, { kind: 'edit' }).plain}
             onSave={(newBody) => {
               if (newBody !== body) {
                 initMatrix.roomsInput.sendEditedMessage(roomId, mEvent, newBody);

--- a/src/client/state/Notifications.js
+++ b/src/client/state/Notifications.js
@@ -10,6 +10,7 @@ import { setFavicon } from '../../util/common';
 import LogoSVG from '../../../public/res/svg/cinny.svg';
 import LogoUnreadSVG from '../../../public/res/svg/cinny-unread.svg';
 import LogoHighlightSVG from '../../../public/res/svg/cinny-highlight.svg';
+import { html, plain } from '../../util/markdown';
 
 function isNotifEvent(mEvent) {
   const eType = mEvent.getType();
@@ -257,8 +258,18 @@ class Notifications extends EventEmitter {
         scale: 8,
       });
 
+      const content = mEvent.getContent();
+
+      const state = { kind: 'notification' };
+      let body;
+      if (content.format === 'org.matrix.custom.html') {
+        body = html(content.formatted_body, state);
+      } else {
+        body = plain(content.body, state);
+      }
+
       const noti = new window.Notification(title, {
-        body: mEvent.getContent().body,
+        body: body.plain,
         icon,
         tag: mEvent.getId(),
         silent: settings.isNotificationSounds,

--- a/src/client/state/Notifications.js
+++ b/src/client/state/Notifications.js
@@ -260,7 +260,7 @@ class Notifications extends EventEmitter {
 
       const content = mEvent.getContent();
 
-      const state = { kind: 'notification' };
+      const state = { kind: 'notification', onlyPlain: true };
       let body;
       if (content.format === 'org.matrix.custom.html') {
         body = html(content.formatted_body, state);

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -199,7 +199,7 @@ class RoomsInput extends EventEmitter {
     const emojis = getShortcodeToEmoji(this.matrixClient, [room, ...parentRooms]);
 
     const output = settings.isMarkdown && autoMarkdown ? markdown : plain;
-    const body = output(message, { kind: 'edit', userNames, emojis });
+    const body = output(message, { userNames, emojis });
 
     const content = {
       body: body.plain,

--- a/src/client/state/RoomsInput.js
+++ b/src/client/state/RoomsInput.js
@@ -199,7 +199,7 @@ class RoomsInput extends EventEmitter {
     const emojis = getShortcodeToEmoji(this.matrixClient, [room, ...parentRooms]);
 
     const output = settings.isMarkdown && autoMarkdown ? markdown : plain;
-    const body = output(message, { userNames, emojis });
+    const body = output(message, { kind: 'edit', userNames, emojis });
 
     const content = {
       body: body.plain,

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -204,3 +204,14 @@ export function scaleDownImage(imageFile, width, height) {
     img.src = imgURL;
   });
 }
+
+/**
+ * @param {sigil} string sigil to search for (for example '@', '#' or '$')
+ * @param {flags} string regex flags
+ * @param {prefix} string prefix appended at the beginning of the regex
+ * @returns {RegExp}
+ */
+export function idRegex(sigil, flags, prefix) {
+  const servername = '(?:[a-zA-Z0-9-.]*[a-zA-Z0-9]+|\\[\\S+?\\])(?::\\d+)?';
+  return new RegExp(`${prefix}(${sigil}\\S+:${servername})`, flags);
+}

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -215,3 +215,16 @@ export function idRegex(sigil, flags, prefix) {
   const servername = '(?:[a-zA-Z0-9-.]*[a-zA-Z0-9]+|\\[\\S+?\\])(?::\\d+)?';
   return new RegExp(`${prefix}(${sigil}\\S+:${servername})`, flags);
 }
+
+const matrixToRegex = /^https?:\/\/matrix.to\/#\/(.+:.+)/;
+/**
+ * Parses a matrix.to URL into an matrix id.
+ * This function can later be extended to support matrix: URIs
+ * @param {string} uri The URI to parse
+ * @returns {string} The id or null if the URI does not match
+ */
+export function parseIdUri(uri) {
+  const res = decodeURIComponent(uri).match(matrixToRegex);
+  if (!res) return null;
+  return res[1];
+}

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -216,12 +216,12 @@ export function idRegex(sigil, flags, prefix) {
   return new RegExp(`${prefix}(${sigil}\\S+:${servername})`, flags);
 }
 
-const matrixToRegex = /^https?:\/\/matrix.to\/#\/(.+:.+)/;
+const matrixToRegex = /^https?:\/\/matrix.to\/#\/(\S+:\S+)/;
 /**
  * Parses a matrix.to URL into an matrix id.
  * This function can later be extended to support matrix: URIs
  * @param {string} uri The URI to parse
- * @returns {string} The id or null if the URI does not match
+ * @returns {string|null} The id or null if the URI does not match
  */
 export function parseIdUri(uri) {
   const res = decodeURIComponent(uri).match(matrixToRegex);

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -138,7 +138,7 @@ const markdownRules = {
   list: {
     ...defaultRules.list,
     plain: (node, output, state) => `${node.items.map((item, i) => {
-      const prefix = node.ordered ? `${node.start + i + 1}. ` : '* ';
+      const prefix = node.ordered ? `${node.start + i}. ` : '* ';
       return prefix + output(item, state).replace(/\n/g, `\n${' '.repeat(prefix.length)}`);
     }).join('\n')}\n`,
   },
@@ -327,14 +327,16 @@ function mapElement(el) {
       return [{ type: 'hr' }];
     case 'PRE': {
       let lang;
-      el.firstChild?.classList.find((c) => {
-        const langPrefix = 'language-';
-        if (c.startsWith(langPrefix)) {
-          lang = c.slice(langPrefix.length);
-          return true;
-        }
-        return false;
-      });
+      if (el.firstChild) {
+        Array.from(el.firstChild.classList).some((c) => {
+          const langPrefix = 'language-';
+          if (c.startsWith(langPrefix)) {
+            lang = c.slice(langPrefix.length);
+            return true;
+          }
+          return false;
+        });
+      }
       return [{ type: 'codeBlock', lang, content: el.innerText }];
     }
     case 'BLOCKQUOTE':
@@ -345,7 +347,7 @@ function mapElement(el) {
       return [{
         type: 'list',
         ordered: true,
-        start: el.getAttribute('start'),
+        start: Number(el.getAttribute('start')),
         items: mapChildren(el),
       }];
     case 'TABLE': {
@@ -387,7 +389,7 @@ function mapElement(el) {
     case 'STRIKE':
       return [{ type: 'del', content: mapChildren(el) }];
     case 'CODE':
-      return [{ type: 'code', content: el.innerText }];
+      return [{ type: 'inlineCode', content: el.innerText }];
 
     case 'DIV':
       if (el.hasAttribute('data-mx-maths')) {

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -462,6 +462,8 @@ function render(content, state, plainOut, htmlOut) {
   }
 
   const plainStr = plainOut(c, state).trim();
+  if (state.onlyPlain) return { plain: plainStr };
+
   const htmlStr = htmlOut(c, state);
 
   const plainHtml = htmlStr.replace(/<br>/g, '\n').replace(/<\/p><p>/g, '\n\n').replace(/<\/?p>/g, '');

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-use-before-define */
 import SimpleMarkdown from '@khanacademy/simple-markdown';
+import { idRegex } from './common';
 
 const {
   defaultRules, parserFor, outputFor, anyScopeRegex, blockRegex, inlineRegex,
@@ -29,11 +30,6 @@ function mathHtml(wrap, node) {
 
 const emojiRegex = /^:([\w-]+):/;
 
-function idRegex(sigil) {
-  const servername = '(?:[a-zA-Z0-9-.]+|\\[\\S+?\\])(?::\\d+)?';
-  return new RegExp(`^(${sigil}\\S+:${servername})`);
-}
-
 const plainRules = {
   Array: {
     ...defaultRules.Array,
@@ -41,7 +37,7 @@ const plainRules = {
   },
   userMention: {
     order: defaultRules.em.order - 0.9,
-    match: inlineRegex(idRegex('@')),
+    match: inlineRegex(idRegex('@', undefined, '^')),
     parse: (capture, _, state) => ({
       content: state.userNames[capture[1]] ? `@${state.userNames[capture[1]]}` : capture[1],
       id: capture[1],
@@ -53,7 +49,7 @@ const plainRules = {
   },
   roomMention: {
     order: defaultRules.em.order - 0.8,
-    match: inlineRegex(idRegex('#')),
+    match: inlineRegex(idRegex('#', undefined, '^')),
     parse: (capture) => ({ content: capture[1], id: capture[1] }),
     plain: (node) => node.content,
     html: (node) => htmlTag('a', sanitizeText(node.content), {

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -96,9 +96,7 @@ const plainRules = {
   text: {
     ...defaultRules.text,
     match: anyScopeRegex(/^[\s\S]+?(?=[^0-9A-Za-z\s\u00c0-\uffff]| *\n|\w+:\S|$)/),
-    plain: (node, _, state) => (state.kind === 'edit'
-      ? node.content.replace(/(\*|_|!\[|\[|\|\||\$\$?)/g, '\\$1')
-      : node.content),
+    plain: (node) => node.content.replace(/(\*|_|!\[|\[|\|\||\$\$?)/g, '\\$1'),
   },
 };
 
@@ -237,10 +235,17 @@ const markdownRules = {
       }
       return out;
     },
-    html: (node, output, state) => htmlTag('a', output(node.content, state), {
-      href: sanitizeUrl(node.target) || '',
-      title: node.title,
-    }),
+    html: (node, output, state) => {
+      const out = output(node.content, state);
+      const target = sanitizeUrl(node.target) || '';
+      if (out !== target || node.title) {
+        return htmlTag('a', out, {
+          href: target,
+          title: node.title,
+        });
+      }
+      return target;
+    },
   },
   image: {
     ...defaultRules.image,

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -47,7 +47,7 @@ const plainRules = {
   },
   roomMention: {
     order: defaultRules.em.order - 0.8,
-    match: inlineRegex(/^(#\S+:\S+)/), // TODO: Handle line beginning with roomMention (instead of heading)
+    match: inlineRegex(/^(#\S+:\S+)/),
     parse: (capture) => ({ content: capture[1], id: capture[1] }),
     plain: (node) => node.content,
     html: (node) => htmlTag('a', sanitizeText(node.content), {
@@ -104,13 +104,8 @@ const markdownRules = {
   ...plainRules,
   heading: {
     ...defaultRules.heading,
-    plain: (node, output, state) => {
-      const out = output(node.content, state);
-      if (node.level <= 2) {
-        return `${out}\n${(node.level === 1 ? '=' : '-').repeat(out.length)}\n\n`;
-      }
-      return `${'#'.repeat(node.level)} ${out}\n\n`;
-    },
+    match: blockRegex(/^ *(#{1,6}) ([^\n]+?)#* *(?:\n *)+\n/),
+    plain: (node, output, state) => `${'#'.repeat(node.level)} ${output(node.content, state)}\n\n`,
   },
   hr: {
     ...defaultRules.hr,

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -105,7 +105,7 @@ const markdownRules = {
   ...plainRules,
   heading: {
     ...defaultRules.heading,
-    match: blockRegex(/^ *(#{1,6}) ([^\n]+?)#* *(?:\n *)+\n/),
+    match: blockRegex(/^ *(#{1,6})([^\n:]*?(?: [^\n]*?)?)#* *(?:\n *)+\n/),
     plain: (node, output, state) => {
       const out = output(node.content, state);
       if (state.kind === 'edit' || state.kind === 'notification' || node.level > 2) {

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -29,6 +29,11 @@ function mathHtml(wrap, node) {
 
 const emojiRegex = /^:([\w-]+):/;
 
+function idRegex(sigil) {
+  const servername = '(?:[a-zA-Z0-9-.]+|\\[\\S+?\\])(?::\\d+)?';
+  return new RegExp(`^(${sigil}\\S+:${servername})`);
+}
+
 const plainRules = {
   Array: {
     ...defaultRules.Array,
@@ -36,7 +41,7 @@ const plainRules = {
   },
   userMention: {
     order: defaultRules.em.order - 0.9,
-    match: inlineRegex(/^(@\S+:\S+)/),
+    match: inlineRegex(idRegex('@')),
     parse: (capture, _, state) => ({
       content: state.userNames[capture[1]] ? `@${state.userNames[capture[1]]}` : capture[1],
       id: capture[1],
@@ -48,7 +53,7 @@ const plainRules = {
   },
   roomMention: {
     order: defaultRules.em.order - 0.8,
-    match: inlineRegex(/^(#\S+:\S+)/),
+    match: inlineRegex(idRegex('#')),
     parse: (capture) => ({ content: capture[1], id: capture[1] }),
     plain: (node) => node.content,
     html: (node) => htmlTag('a', sanitizeText(node.content), {

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -97,7 +97,7 @@ const plainRules = {
     ...defaultRules.text,
     match: anyScopeRegex(/^[\s\S]+?(?=[^0-9A-Za-z\s\u00c0-\uffff]| *\n|\w+:\S|$)/),
     plain: (node, _, state) => (state.kind === 'edit'
-      ? node.content.replace(/(\*|_|\|\||\$\$?)/g, '\\$1')
+      ? node.content.replace(/(\*|_|!\[|\[|\|\||\$\$?)/g, '\\$1')
       : node.content),
   },
 };
@@ -376,13 +376,30 @@ function mapElement(el) {
         content: mapChildren(el),
       }];
     }
-    case 'IMG':
+    case 'IMG': {
+      const src = el.getAttribute('src');
+      let title = el.getAttribute('title');
+      if (el.hasAttribute('data-mx-emoticon')) {
+        if (title.length > 2 && title.startsWith(':') && title.endsWith(':')) {
+          title = title.slice(1, -1);
+        }
+        return [{
+          type: 'emoji',
+          content: title,
+          emoji: {
+            mxc: src,
+            shortcode: title,
+          },
+        }];
+      }
+
       return [{
-        type: 'img',
+        type: 'image',
         alt: el.getAttribute('alt'),
-        target: el.getAttribute('src'),
-        title: el.getAttribute('title'),
+        target: src,
+        title,
       }];
+    }
     case 'EM':
     case 'I':
       return [{ type: 'em', content: mapChildren(el) }];

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -32,7 +32,7 @@ const emojiRegex = /^:([\w-]+):/;
 const plainRules = {
   Array: {
     ...defaultRules.Array,
-    plain: (arr, output, state) => arr.map((node) => output(node, state)).join(''),
+    plain: defaultRules.Array.html,
   },
   userMention: {
     order: defaultRules.em.order - 0.9,
@@ -96,7 +96,9 @@ const plainRules = {
   text: {
     ...defaultRules.text,
     match: anyScopeRegex(/^[\s\S]+?(?=[^0-9A-Za-z\s\u00c0-\uffff]| *\n|\w+:\S|$)/),
-    plain: (node) => node.content,
+    plain: (node, _, state) => (state.kind === 'edit'
+      ? node.content.replace(/(\*|_|\|\||\$\$?)/g, '\\$1')
+      : node.content),
   },
 };
 

--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -266,7 +266,17 @@ const markdownRules = {
       content: parse(capture[1], state),
       reason: capture[2],
     }),
-    plain: (node, output, state) => `[spoiler${node.reason ? `: ${node.reason}` : ''}](${output(node.content, state)})`,
+    plain: (node, output, state) => {
+      const warning = `spoiler${node.reason ? `: ${node.reason}` : ''}`;
+      switch (state.kind) {
+        case 'edit':
+          return `||${output(node.content, state)}||`;
+        case 'notification':
+          return `<${warning}>`;
+        default:
+          return `[${warning}](${output(node.content, state)})`;
+      }
+    },
     html: (node, output, state) => htmlTag(
       'span',
       output(node.content, state),


### PR DESCRIPTION
### Description
This parses the `formatted_body` (if available) into the markdown ast to then render it as plaintext. This allows spoilers to not be visible in notifications (now showing up as `<spoiler>`), while still showing during edits as `||spoiler||` and in the future as `[spoiler](mxc://somewhere)` in the `body` shown in plaintext clients.

#### Type of change 

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


























<!-- Replace -->
Preview: https://847--pr-cinny.netlify.app
⚠️ Exercise caution. Use test accounts. ⚠️
<!-- Replace -->
