### PR TITLE
Add Dev Container and Codespaces environment support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:18",
+    "forwardPorts": [8080],
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+				"ms-vscode.vscode-typescript-next",
+				"dbaeumer.vscode-eslint",
+                "mutantdino.resourcemonitor"
+			]
+        }
+    }
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "type": "node",
+            "name": "start",
+            "request": "launch",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run-script",
+                "start"
+            ],
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ To build the app:
 npm run build # Compiles the app into the dist/ directory
 ```
 
+### Dev Container
+A Dev Container configuration is included with the repository: it setups Node and configures Visual Studio Code for you, and, if you're using GitHub Codespaces, automatically tweaks the webpack configuration to allow remote development.
+
+Inside the codespace, you'll still need to install all dependencies as described in [the section above](local-development).
+
+> You can read more about [Dev Containers](https://code.visualstudio.com/docs/devcontainers/create-dev-container) and [Codespaces](https://github.com/features/codespaces) on their respective documentation page.
+
 ### Running with Docker
 This repository includes a Dockerfile, which builds the application from source and serves it with Nginx on port 80. To
 use this locally, you can build the container like so:

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -2,6 +2,7 @@ const path = require('path');
 const common = require('./webpack.common');
 const { merge } = require('webpack-merge');
 
+
 module.exports = merge(common, {
   mode: 'development',
   output: {
@@ -11,6 +12,10 @@ module.exports = merge(common, {
   },
   devServer: {
     historyApiFallback: true,
+    client: {
+      webSocketURL: "auto://0.0.0.0:0/ws"
+    },
+    allowedHosts: process.env.CODESPACES ? [".preview.app.github.dev"] : "auto"
   },
   module: {
     rules: [


### PR DESCRIPTION
### Description

This pull request defines a Dev Container which configures Cinny's dependencies for an easier development, and applies some changes to Webpack's config to allow running and debugging Cinny via GitHub Codespaces. 

Reasoning for the changes is included **inside the commit messages**.

_Please check that my Webpack changes do not break the "regular" development workflow, as I've had no way to test it myself!_

### Type of change

- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [x] New feature (non-breaking change which adds functionality)
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- [x] This change requires a documentation update

### Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

### Screenshots

![The "Create Codespace" button on the GitHub repository](https://user-images.githubusercontent.com/1540885/202827250-b6efdc19-9674-4f3c-9267-b096e266c775.png)

![Visual Studio Code, editing the Cinny repository, running in a web page, via GitHub Codespaces](https://user-images.githubusercontent.com/1540885/202827609-205004db-a16c-4a36-8e88-89b56343bed4.png)

![The forwarded port panel of Visual Studio Code, port 8080 is forwarded to a .github.dev URL](https://user-images.githubusercontent.com/1540885/202827698-9cb195d7-2295-4865-a575-eb90cb0f9c00.png)

![Cinny being run via the Run and Debug panel of Visual Studio Code](https://user-images.githubusercontent.com/1540885/202827770-4945eff1-0132-4f53-bc5f-880f6caf58b1.png)

![Development version of Cinny running at the URL where port 8080 was previously forwarded](https://user-images.githubusercontent.com/1540885/202827862-393fe548-aab0-44ff-b218-6a9b7998c3e9.png)

