### PR TITLE
Change file size indicator to use IEC 80000-13 byte units

### DIFF
--- a/src/util/common.js
+++ b/src/util/common.js
@@ -1,6 +1,8 @@
 /* eslint-disable max-classes-per-file */
 export function bytesToSize(bytes) {
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+  // IEC 80000-13
+  // https://en.wikipedia.org/wiki/Kilobyte
+  const sizes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
   if (bytes === 0) return 'n/a';
   const i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)), 10);
   if (i === 0) return `${bytes} ${sizes[i]}`;


### PR DESCRIPTION
Since Cinny is counting bytes as powers of 1024, it should display the [binary units of measurment kibibyte, mebibyte, gibibyte, and so on](https://en.wikipedia.org/wiki/Kilobyte).

![An image being sent, displaying a size of 66.5 KiB.](https://user-images.githubusercontent.com/1540885/203941549-4e56e712-d254-4efc-8484-1384746a33ca.png)

Possibly fixes #986?

#### Type of change

- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- [ ] ~~This change requires a documentation update~~

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
