### PR TITLE
Add `accept` attribute to `image/*` to the `ImageUpload` component

### DIFF
--- a/src/app/molecules/image-upload/ImageUpload.jsx
+++ b/src/app/molecules/image-upload/ImageUpload.jsx
@@ -74,7 +74,7 @@ function ImageUpload({
           <Text variant="b3">{uploadPromise ? 'Cancel' : 'Remove'}</Text>
         </button>
       )}
-      <input onChange={uploadImage} style={{ display: 'none' }} ref={uploadImageRef} type="file" />
+      <input onChange={uploadImage} style={{ display: 'none' }} ref={uploadImageRef} type="file" accept="image/*" />
     </div>
   );
 }


### PR DESCRIPTION
That way, browsers will suggest to the users to upload an image file instead of any kind of file.

![KDE Plasma's file picker, now having the Image Files filter available.](https://user-images.githubusercontent.com/1540885/203945089-13501849-5b04-47cd-835a-81c8b4b50b57.png)

The behaviour is in-line with Element's, which specifies the same attribute when selecting an avatar.

Please note that it does not prevent users from uploading non-image files as avatars, as browsers interpret that attribute as a mere suggestion, which can be bypassed in the file select dialog.

Partially fixes #982.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- [ ] ~~This change requires a documentation update~~

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
