### PR TITLE
Fix twemoji cdn + add twemoji assets to public

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.2.0
+        with: 
+          submodules: true
       - name: Setup node
         uses: actions/setup-node@v3.5.1
         with:

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.2.0
+        with: 
+          submodules: true
       - name: Build Docker image
         uses: docker/build-push-action@v3.2.0
         with:

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3.2.0
+        with: 
+          submodules: true
       - name: NPM Lockfile Changes
         uses: codepunkt/npm-lockfile-changes@b40543471c36394409466fdb277a73a0856d7891
         with:

--- a/.github/workflows/netlify-dev.yml
+++ b/.github/workflows/netlify-dev.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.2.0
+        with: 
+          submodules: true
       - name: Setup node
         uses: actions/setup-node@v3.5.1
         with:

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3.2.0
+        with: 
+          submodules: true
       - name: Setup node
         uses: actions/setup-node@v3.5.1
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "public/res/twemoji"]
-	path = public/res/twemoji
+[submodule "deps/twemoji"]
+	path = deps/twemoji
 	url = https://github.com/twitter/twemoji.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "public/res/twemoji"]
+	path = public/res/twemoji
+	url = https://github.com/twitter/twemoji.git

--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -30,7 +30,7 @@ import PhotoIC from '../../../../public/res/ic/outlined/photo.svg';
 import BulbIC from '../../../../public/res/ic/outlined/bulb.svg';
 import PeaceIC from '../../../../public/res/ic/outlined/peace.svg';
 import FlagIC from '../../../../public/res/ic/outlined/flag.svg';
-import { getTwemojiCDN } from '../../../util/twemojify';
+import { getTwemojiBaseUrl } from '../../../util/twemojify';
 
 const ROW_EMOJIS_COUNT = 7;
 
@@ -38,7 +38,7 @@ const EmojiGroup = React.memo(({ name, groupEmojis }) => {
   function getEmojiBoard() {
     const emojiBoard = [];
     const totalEmojis = groupEmojis.length;
-    var cdn = getTwemojiCDN()
+
     for (let r = 0; r < totalEmojis; r += ROW_EMOJIS_COUNT) {
       const emojiRow = [];
       for (let c = r; c < r + ROW_EMOJIS_COUNT; c += 1) {
@@ -59,7 +59,7 @@ const EmojiGroup = React.memo(({ name, groupEmojis }) => {
                       hexcode: emoji.hexcode,
                       loading: 'lazy',
                     }),
-                    base: cdn,
+                    base: getTwemojiBaseUrl(),
                   },
                 ))
                 // This is a custom emoji, and should be render as an mxc
@@ -252,8 +252,6 @@ function EmojiBoard({ onSelect, searchRef }) {
     $emojiContent.children[tabIndex].scrollIntoView();
   }
 
-  var cdn = getTwemojiCDN()
-
   return (
     <div id="emoji-board" className="emoji-board">
       <ScrollView invisible>
@@ -337,7 +335,7 @@ function EmojiBoard({ onSelect, searchRef }) {
           </ScrollView>
         </div>
         <div ref={emojiInfo} className="emoji-board__content__info">
-          <div>{ parse(twemoji.parse('🙂', {base: cdn})) }</div>
+          <div>{ parse(twemoji.parse('🙂', {base: getTwemojiBaseUrl()})) }</div>
           <Text>:slight_smile:</Text>
         </div>
       </div>

--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -30,7 +30,7 @@ import PhotoIC from '../../../../public/res/ic/outlined/photo.svg';
 import BulbIC from '../../../../public/res/ic/outlined/bulb.svg';
 import PeaceIC from '../../../../public/res/ic/outlined/peace.svg';
 import FlagIC from '../../../../public/res/ic/outlined/flag.svg';
-import { GetTwemojiCDN } from '../../../util/twemojify';
+import { getTwemojiCDN } from '../../../util/twemojify';
 
 const ROW_EMOJIS_COUNT = 7;
 
@@ -38,7 +38,7 @@ const EmojiGroup = React.memo(({ name, groupEmojis }) => {
   function getEmojiBoard() {
     const emojiBoard = [];
     const totalEmojis = groupEmojis.length;
-    var cdn = GetTwemojiCDN()
+    var cdn = getTwemojiCDN()
     for (let r = 0; r < totalEmojis; r += ROW_EMOJIS_COUNT) {
       const emojiRow = [];
       for (let c = r; c < r + ROW_EMOJIS_COUNT; c += 1) {
@@ -252,7 +252,7 @@ function EmojiBoard({ onSelect, searchRef }) {
     $emojiContent.children[tabIndex].scrollIntoView();
   }
 
-  var cdn = GetTwemojiCDN()
+  var cdn = getTwemojiCDN()
 
   return (
     <div id="emoji-board" className="emoji-board">

--- a/src/app/organisms/emoji-board/EmojiBoard.jsx
+++ b/src/app/organisms/emoji-board/EmojiBoard.jsx
@@ -30,6 +30,7 @@ import PhotoIC from '../../../../public/res/ic/outlined/photo.svg';
 import BulbIC from '../../../../public/res/ic/outlined/bulb.svg';
 import PeaceIC from '../../../../public/res/ic/outlined/peace.svg';
 import FlagIC from '../../../../public/res/ic/outlined/flag.svg';
+import { GetTwemojiCDN } from '../../../util/twemojify';
 
 const ROW_EMOJIS_COUNT = 7;
 
@@ -37,7 +38,7 @@ const EmojiGroup = React.memo(({ name, groupEmojis }) => {
   function getEmojiBoard() {
     const emojiBoard = [];
     const totalEmojis = groupEmojis.length;
-
+    var cdn = GetTwemojiCDN()
     for (let r = 0; r < totalEmojis; r += ROW_EMOJIS_COUNT) {
       const emojiRow = [];
       for (let c = r; c < r + ROW_EMOJIS_COUNT; c += 1) {
@@ -58,6 +59,7 @@ const EmojiGroup = React.memo(({ name, groupEmojis }) => {
                       hexcode: emoji.hexcode,
                       loading: 'lazy',
                     }),
+                    base: cdn,
                   },
                 ))
                 // This is a custom emoji, and should be render as an mxc
@@ -250,6 +252,8 @@ function EmojiBoard({ onSelect, searchRef }) {
     $emojiContent.children[tabIndex].scrollIntoView();
   }
 
+  var cdn = GetTwemojiCDN()
+
   return (
     <div id="emoji-board" className="emoji-board">
       <ScrollView invisible>
@@ -333,7 +337,7 @@ function EmojiBoard({ onSelect, searchRef }) {
           </ScrollView>
         </div>
         <div ref={emojiInfo} className="emoji-board__content__info">
-          <div>{ parse(twemoji.parse('🙂')) }</div>
+          <div>{ parse(twemoji.parse('🙂', {base: cdn})) }</div>
           <Text>:slight_smile:</Text>
         </div>
       </div>

--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -5,7 +5,7 @@ import './RoomViewCmdBar.scss';
 import parse from 'html-react-parser';
 import twemoji from 'twemoji';
 
-import { GetTwemojiCDN, twemojify } from '../../../util/twemojify';
+import { getTwemojiCDN, twemojify } from '../../../util/twemojify';
 
 import initMatrix from '../../../client/initMatrix';
 import { getEmojiForCompletion } from '../emoji-board/custom-emoji';
@@ -60,7 +60,7 @@ function renderSuggestions({ prefix, option, suggestions }, fireCmd) {
             unicode: emoji.unicode,
             shortcodes: emoji.shortcodes?.toString(),
           }),
-          base: GetTwemojiCDN()
+          base: getTwemojiCDN()
         },
       ));
     }

--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -5,7 +5,7 @@ import './RoomViewCmdBar.scss';
 import parse from 'html-react-parser';
 import twemoji from 'twemoji';
 
-import { twemojify } from '../../../util/twemojify';
+import { GetTwemojiCDN, twemojify } from '../../../util/twemojify';
 
 import initMatrix from '../../../client/initMatrix';
 import { getEmojiForCompletion } from '../emoji-board/custom-emoji';
@@ -60,6 +60,7 @@ function renderSuggestions({ prefix, option, suggestions }, fireCmd) {
             unicode: emoji.unicode,
             shortcodes: emoji.shortcodes?.toString(),
           }),
+          base: GetTwemojiCDN()
         },
       ));
     }

--- a/src/app/organisms/room/RoomViewCmdBar.jsx
+++ b/src/app/organisms/room/RoomViewCmdBar.jsx
@@ -5,7 +5,7 @@ import './RoomViewCmdBar.scss';
 import parse from 'html-react-parser';
 import twemoji from 'twemoji';
 
-import { getTwemojiCDN, twemojify } from '../../../util/twemojify';
+import { getTwemojiBaseUrl, twemojify } from '../../../util/twemojify';
 
 import initMatrix from '../../../client/initMatrix';
 import { getEmojiForCompletion } from '../emoji-board/custom-emoji';
@@ -60,7 +60,7 @@ function renderSuggestions({ prefix, option, suggestions }, fireCmd) {
             unicode: emoji.unicode,
             shortcodes: emoji.shortcodes?.toString(),
           }),
-          base: getTwemojiCDN()
+          base: getTwemojiBaseUrl()
         },
       ));
     }

--- a/src/util/twemojify.jsx
+++ b/src/util/twemojify.jsx
@@ -8,11 +8,13 @@ import { sanitizeText } from './sanitize';
 
 const Math = lazy(() => import('../app/atoms/math/Math'));
 
-const CDN_LOCAL = "/public/res/twemoji/assets/"
+const CDN_LOCAL = "/public/twemoji/assets/"
 const CDN_EXTERNAL = "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/";
 
+var use_local = false;
+
 export const GetTwemojiCDN = () => {
-  if(window.__TAURI__){
+  if(window.__TAURI__ || use_local){
     return CDN_LOCAL
   }
   else{

--- a/src/util/twemojify.jsx
+++ b/src/util/twemojify.jsx
@@ -8,19 +8,9 @@ import { sanitizeText } from './sanitize';
 
 const Math = lazy(() => import('../app/atoms/math/Math'));
 
-const CDN_LOCAL = '/public/twemoji/assets/'
-const CDN_EXTERNAL = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/';
+const TWEMOJI_BASE_URL = '/public/twemoji/assets/'
 
-var use_local = false;
-
-export const getTwemojiCDN = () => {
-  if(window.__TAURI__ || use_local){
-    return CDN_LOCAL
-  }
-  else{
-    return CDN_EXTERNAL
-  }
-};
+export const getTwemojiBaseUrl = () => TWEMOJI_BASE_URL;
 
 const mathOptions = {
   replace: (node) => {
@@ -57,13 +47,16 @@ export function twemojify(text, opts, linkify = false, sanitize = true, maths = 
     content = sanitizeText(content);
   }
   
-  if(opts){
-    opts.base = getTwemojiCDN()
-  } else {
-    opts = { base: getTwemojiCDN() }
+  let options = opts;
+
+  if(!options){
+    options = { base: getTwemojiBaseUrl() }
+  } 
+  else if(!options.base){
+    options.base = getTwemojiBaseUrl()
   }
-  
-  content = twemoji.parse(content, opts);
+
+  content = twemoji.parse(content, options);
   
   if (linkify) {
     content = linkifyHtml(content, {

--- a/src/util/twemojify.jsx
+++ b/src/util/twemojify.jsx
@@ -8,12 +8,12 @@ import { sanitizeText } from './sanitize';
 
 const Math = lazy(() => import('../app/atoms/math/Math'));
 
-const CDN_LOCAL = "/public/twemoji/assets/"
-const CDN_EXTERNAL = "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/";
+const CDN_LOCAL = '/public/twemoji/assets/'
+const CDN_EXTERNAL = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/';
 
 var use_local = false;
 
-export const GetTwemojiCDN = () => {
+export const getTwemojiCDN = () => {
   if(window.__TAURI__ || use_local){
     return CDN_LOCAL
   }
@@ -21,8 +21,6 @@ export const GetTwemojiCDN = () => {
     return CDN_EXTERNAL
   }
 };
-
-
 
 const mathOptions = {
   replace: (node) => {
@@ -60,9 +58,9 @@ export function twemojify(text, opts, linkify = false, sanitize = true, maths = 
   }
   
   if(opts){
-    opts.base = GetTwemojiCDN()
+    opts.base = getTwemojiCDN()
   } else {
-    opts = { base: GetTwemojiCDN() }
+    opts = { base: getTwemojiCDN() }
   }
   
   content = twemoji.parse(content, opts);

--- a/src/util/twemojify.jsx
+++ b/src/util/twemojify.jsx
@@ -8,6 +8,20 @@ import { sanitizeText } from './sanitize';
 
 const Math = lazy(() => import('../app/atoms/math/Math'));
 
+const CDN_LOCAL = "/public/res/twemoji/assets/"
+const CDN_EXTERNAL = "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/";
+
+export const GetTwemojiCDN = () => {
+  if(window.__TAURI__){
+    return CDN_LOCAL
+  }
+  else{
+    return CDN_EXTERNAL
+  }
+};
+
+
+
 const mathOptions = {
   replace: (node) => {
     const maths = node.attribs?.['data-mx-maths'];
@@ -42,7 +56,15 @@ export function twemojify(text, opts, linkify = false, sanitize = true, maths = 
   if (sanitize) {
     content = sanitizeText(content);
   }
+  
+  if(opts){
+    opts.base = GetTwemojiCDN()
+  } else {
+    opts = { base: GetTwemojiCDN() }
+  }
+  
   content = twemoji.parse(content, opts);
+  
   if (linkify) {
     content = linkifyHtml(content, {
       target: '_blank',

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,10 @@ const copyFiles = {
     {
       src: 'public/res/android',
       dest: 'public/',
+    },
+    {
+      src: 'deps/twemoji/assets',
+      dest: 'public/twemoji'
     }
   ],
 }


### PR DESCRIPTION
### Description

Due to the twemoji cdn outage, we need to use a different cdn. I am also taking this opportunity to include the twemoji assets in the app itself, for use in cinny-desktop.

This adds [twitter/twemoji](https://github.com/twitter/twemoji/) as a submodule in /deps/twemoji

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
