### PR TITLE
Fix messages getting sent when confirming an input method selection

### DIFF
--- a/src/app/organisms/room/RoomViewInput.jsx
+++ b/src/app/organisms/room/RoomViewInput.jsx
@@ -296,7 +296,7 @@ function RoomViewInput({
       roomsInput.cancelReplyTo(roomId);
       setReplyTo(null);
     }
-    if (e.key === 'Enter' && e.shiftKey === false) {
+    if (e.key === 'Enter' && e.shiftKey === false && e.keyCode !== 229) {
       e.preventDefault();
       sendMessage();
     }


### PR DESCRIPTION
### Description

When using a CJK input method, the enter key is used to confirm the current conversion, so it shouldn't send the message yet. Normally this can be checked with the `isComposing` property of the native event, but that doesn't work on the macOS webview.

Instead, check for `keyCode` 229, which is what you get when confirming conversions, and ignore it.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
