### PR TITLE
Add sticky tabs for the main Settings and SpaceSettings dialogs

### DIFF
--- a/src/app/organisms/settings/Settings.scss
+++ b/src/app/organisms/settings/Settings.scss
@@ -16,8 +16,17 @@
     padding: var(--sp-loose) var(--sp-extra-loose);
   } 
 
-  & .tabs__content {
-    padding: 0 var(--sp-normal);
+  & .tabs {
+    position: sticky;
+    top: 0;
+    z-index: 999;
+    background-color: var(--bg-surface-low);
+    box-shadow: 0 -4px 0 var(--bg-surface-low),
+      inset 0 -1px 0 var(--bg-surface-border);
+
+    &__content {
+      padding: 0 var(--sp-normal);
+    }
   }
 
   &__cards-wrapper {

--- a/src/app/organisms/space-settings/SpaceSettings.scss
+++ b/src/app/organisms/space-settings/SpaceSettings.scss
@@ -9,8 +9,17 @@
     padding: var(--sp-loose) var(--sp-extra-loose);
   } 
 
-  & .tabs__content {
-    padding: 0 var(--sp-normal);
+  & .tabs {
+    position: sticky;
+    top: 0;
+    z-index: 999;
+    background-color: var(--bg-surface-low);
+    box-shadow: 0 -4px 0 var(--bg-surface-low),
+      inset 0 -1px 0 var(--bg-surface-border);
+
+    &__content {
+      padding: 0 var(--sp-normal);
+    }
   }
 
   &__cards-wrapper {


### PR DESCRIPTION
- Add sticky positioning for tabs on the Settings panel
- Also add sticky position for SpaceSettings

<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The RoomSettings dialog uses sticky positioning for the tabs. I noticed that the
other Settings and SpaceSettings dialogs don't also have this. This is just a
small patch that uses the same settings on the other side.

It maybe be a good future extension to have this be an option on the tabs
themselves, or to make a wrapper component that implements the sticky. Let me
know if that's more preferable than this patch.

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
