### PR TITLE
Fix message box height not restored

### DIFF
--- a/src/app/organisms/room/RoomViewInput.jsx
+++ b/src/app/organisms/room/RoomViewInput.jsx
@@ -45,6 +45,7 @@ function RoomViewInput({
   const [attachment, setAttachment] = useState(null);
   const [replyTo, setReplyTo] = useState(null);
   const [message, setMessage] = useState('');
+  const [addedEmoji, setAddedEmoji] = useState('');
 
   const textAreaRef = useRef(null);
   const inputBaseRef = useRef(null);
@@ -335,9 +336,15 @@ function RoomViewInput({
   };
 
   function addEmoji(emoji) {
-    setMessage(message + emoji.unicode);
+    setAddedEmoji(emoji.unicode);
     textAreaRef.current.focus();
   }
+
+  useEffect(() => {
+    setMessage(message + addedEmoji);
+    // this does not create an infinite loop because addedEmoji value remains the same
+    setAddedEmoji('');
+  }, [addedEmoji]);
 
   const handleUploadClick = () => {
     if (attachment === null) uploadInputRef.current.click();

--- a/src/app/organisms/room/RoomViewInput.jsx
+++ b/src/app/organisms/room/RoomViewInput.jsx
@@ -178,17 +178,6 @@ function RoomViewInput({
     };
   }, [roomId]);
 
-  useEffect(
-    () => () => {
-      if (message.trim() === '') {
-        roomsInput.setMessage(roomId, '');
-      } else {
-        roomsInput.setMessage(roomId, message);
-      }
-    },
-    [message, roomId]
-  );
-
   const sendBody = async (body, options) => {
     const opt = options ?? {};
     if (!opt.msgType) opt.msgType = 'm.text';
@@ -293,7 +282,12 @@ function RoomViewInput({
   const handleMsgTyping = (e) => {
     const msg = e.target.value;
     setMessage(msg);
-    recognizeCmd(e.target.value);
+    if (msg.trim() === '') {
+      roomsInput.setMessage(roomId, '');
+    } else {
+      roomsInput.setMessage(roomId, msg);
+    }
+    recognizeCmd(msg);
     if (!isCmdActivated) processTyping(msg);
   };
 
@@ -342,6 +336,7 @@ function RoomViewInput({
 
   useEffect(() => {
     setMessage(message + addedEmoji);
+    roomsInput.setMessage(roomId, message + addedEmoji);
     // this does not create an infinite loop because addedEmoji value remains the same
     setAddedEmoji('');
   }, [addedEmoji]);


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
react-autosize-textarea does not re-render when modified with textAreaRef.current.value, so I moved the message box contents out to a state. The textarea height is now properly updated

Fixes #422

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
