### PR TITLE
Simplify space to room mapping logic

### DIFF
--- a/src/client/state/navigation.js
+++ b/src/client/state/navigation.js
@@ -39,7 +39,7 @@ class Navigation extends EventEmitter {
   }
 
   _mapRoomToSpace(roomId) {
-    const { roomList, accountData } = this.initMatrix;
+    const { roomList } = this.initMatrix;
     if (
       this.selectedTab === cons.tabs.HOME
       && roomList.rooms.has(roomId)
@@ -59,23 +59,10 @@ class Navigation extends EventEmitter {
       return;
     }
 
-    const parents = roomList.roomIdToParents.get(roomId);
-    if (!parents) return;
-    if (parents.has(this.selectedSpaceId)) {
-      this.spaceToRoom.set(this.selectedSpaceId, {
-        roomId,
-        timestamp: Date.now(),
-      });
-    } else if (accountData.categorizedSpaces.has(this.selectedSpaceId)) {
-      const categories = roomList.getCategorizedSpaces([this.selectedSpaceId]);
-      const parent = [...parents].find((pId) => categories.has(pId));
-      if (parent) {
-        this.spaceToRoom.set(parent, {
-          roomId,
-          timestamp: Date.now(),
-        });
-      }
-    }
+    this.spaceToRoom.set(this.selectedSpaceId, {
+      roomId,
+      timestamp: Date.now(),
+    });
   }
 
   _selectRoom(roomId, eventId) {
@@ -202,7 +189,7 @@ class Navigation extends EventEmitter {
     const { categorizedSpaces } = accountData;
 
     const data = this.spaceToRoom.get(spaceId);
-    if (data && !categorizedSpaces.has(spaceId)) {
+    if (data) {
       this._selectRoom(data.roomId);
       return;
     }
@@ -211,13 +198,6 @@ class Navigation extends EventEmitter {
 
     if (categorizedSpaces.has(spaceId)) {
       const categories = roomList.getCategorizedSpaces([spaceId]);
-
-      const latestSelectedRoom = this._getLatestSelectedRoomId([...categories.keys()]);
-
-      if (latestSelectedRoom) {
-        this._selectRoom(latestSelectedRoom);
-        return;
-      }
 
       categories?.forEach((categoryId) => {
         categoryId?.forEach((childId) => {


### PR DESCRIPTION
### Description
Simplifies logic controlling which room will be displayed when you select a space. Right now it's pretty complicated, but with this patch it will always be the last room that was selected when the space was selected, which I believe is the most intuitive behavior.


Fixes #353 a bit more

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
