### PR TITLE
Fix overly strict emoji regex

### DIFF
--- a/src/util/markdown.js
+++ b/src/util/markdown.js
@@ -29,7 +29,7 @@ function mathHtml(wrap, node) {
   return htmlTag(wrap, htmlTag('code', sanitizeText(node.content)), { 'data-mx-maths': node.content });
 }
 
-const emojiRegex = /^:([\w-]+):/;
+const emojiRegex = /^:([^:]+):/;
 
 const plainRules = {
   Array: {


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Slackens emoji regex to capture any string between two colons as a key candidate.


Fixes #1182

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
