### PR TITLE
Added paste image support on Tauri

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fontsource/roboto": "4.5.8",
         "@khanacademy/simple-markdown": "0.8.6",
         "@matrix-org/olm": "3.2.14",
+        "@tauri-apps/api": "1.3.0",
         "@tippyjs/react": "4.2.6",
         "blurhash": "2.0.4",
         "browser-encrypt-attachment": "0.3.0",
@@ -1102,6 +1103,20 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-1.3.0.tgz",
+      "integrity": "sha512-AH+3FonkKZNtfRtGrObY38PrzEj4d+1emCbwNGu0V2ENbXjlLHMZQlUh+Bhu/CRmjaIwZMGJ3yFvWaZZgTHoog==",
+      "engines": {
+        "node": ">= 14.6.0",
+        "npm": ">= 6.6.0",
+        "yarn": ">= 1.19.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
     },
     "node_modules/@tippyjs/react": {
       "version": "4.2.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@fontsource/roboto": "4.5.8",
     "@khanacademy/simple-markdown": "0.8.6",
     "@matrix-org/olm": "3.2.14",
+    "@tauri-apps/api": "1.3.0",
     "@tippyjs/react": "4.2.6",
     "blurhash": "2.0.4",
     "browser-encrypt-attachment": "0.3.0",

--- a/src/util/common.js
+++ b/src/util/common.js
@@ -228,3 +228,21 @@ export function parseIdUri(uri) {
   if (!res) return null;
   return res[1];
 }
+
+/**
+ * @param {string} base64
+ * @param {string} filename
+ * @param {string} type
+ * @returns {File}
+ */
+export function base64ToFile(base64,filename, type) {
+  const binary = atob(base64)
+  let n = binary.length
+  const u8arr = new Uint8Array(n);
+
+  while(n--){
+    u8arr[n] = binary.charCodeAt(n);
+  }
+
+  return new File([u8arr], filename, {type});
+}


### PR DESCRIPTION
### Description

This PR introduces support to paste images when Cinny is running in the context of Tauri (cinny-desktop).

The implementation calls a new Tauri command introduced in https://github.com/cinnyapp/cinny-desktop/pull/167. If an image is found in the clipboard, it is attached to the message. If not, the same logic as before will be used to populate the field from the clipboard.

This PR depends on https://github.com/cinnyapp/cinny-desktop/pull/167

Fixes https://github.com/cinnyapp/cinny-desktop/issues/69

Tested on Ubuntu 22.04 LTS on Wayland.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
