### PR TITLE
Fix edge case sticker sending and displaying

### DIFF
--- a/src/app/molecules/message/Message.jsx
+++ b/src/app/molecules/message/Message.jsx
@@ -619,7 +619,7 @@ MessageOptions.propTypes = {
 function genMediaContent(mE) {
   const mx = initMatrix.matrixClient;
   const mContent = mE.getContent();
-  if (!mContent || !mContent.body) return <span style={{ color: 'var(--bg-danger)' }}>Malformed event</span>;
+  if (mE.getType() !== "m.sticker" && (!mContent || !mContent.body)) return <span style={{ color: 'var(--bg-danger)' }}>Malformed event</span>;
 
   let mediaMXC = mContent?.url;
   const isEncryptedFile = typeof mediaMXC === 'undefined';

--- a/src/app/organisms/sticker-board/StickerBoard.jsx
+++ b/src/app/organisms/sticker-board/StickerBoard.jsx
@@ -29,7 +29,7 @@ function StickerBoard({ roomId, onSelect }) {
   }
   function getStickerData(target) {
     const mxc = target.getAttribute('data-mx-sticker');
-    const body = target.getAttribute('title');
+    const body = target.getAttribute('title') ? target.getAttribute('title') : target.getAttribute('alt');
     const httpUrl = target.getAttribute('src');
     return { mxc, body, httpUrl };
   }


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes cinny sending empty bodied stickers when sticker title is empty
- Should fix displaying stickers with empty body as "Malformed Event"

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
