### PR TITLE
Prevent `manifest.json` from being inlined

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 
     <link id="favicon" rel="shortcut icon" href="./public/favicon.ico" />
 
-    <link rel="manifest" href="./public/manifest.json" />
+    <link rel="manifest" href="/manifest.json" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="application-name" content="Cinny" />
     <meta name="apple-mobile-web-app-title" content="Cinny" />

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,9 +22,13 @@ const copyFiles = {
       dest: '',
     },
     {
+      src: `public/manifest.json`,
+      dest: ``,
+    },
+    {
       src: 'public/res/android',
       dest: 'public/',
-    }
+    },
   ],
 }
 
@@ -61,7 +65,6 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: true,
     copyPublicDir: false,
-    assetsInlineLimit: 0,
     rollupOptions: {
       plugins: [
         inject({ Buffer: ['buffer', 'Buffer'] })

--- a/vite.config.js
+++ b/vite.config.js
@@ -61,6 +61,7 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: true,
     copyPublicDir: false,
+    assetsInlineLimit: 0,
     rollupOptions: {
       plugins: [
         inject({ Buffer: ['buffer', 'Buffer'] })

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,8 +22,8 @@ const copyFiles = {
       dest: '',
     },
     {
-      src: `public/manifest.json`,
-      dest: ``,
+      src: 'public/manifest.json',
+      dest: '',
     },
     {
       src: 'public/res/android',


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
With vite's asset inlining enabled `manifest.json` isn't detected, which results in browsers not treating Cinny as an installable webapp.


Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
