### PR TITLE
Fix notifications not displaying when document is not focused

### DIFF
--- a/src/client/state/Notifications.js
+++ b/src/client/state/Notifications.js
@@ -234,7 +234,7 @@ class Notifications extends EventEmitter {
     const actions = this.matrixClient.getPushActionsForEvent(mEvent);
     if (!actions?.notify) return;
 
-    if (navigation.selectedRoomId === room.roomId && document.visibilityState === 'visible') return;
+    if (navigation.selectedRoomId === room.roomId && document.hasFocus()) return;
 
     if (mEvent.isEncrypted()) {
       await mEvent.attemptDecryption(this.matrixClient.crypto);


### PR DESCRIPTION
Allows notifications from the active room to display while app is not focused (e.g. tabbed out, different workspace)

<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Bug fix. Very minor change.


Fixes # https://github.com/cinnyapp/cinny-desktop/issues/108

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] (N/A) I have commented my code, particularly in hard-to-understand areas
- [x] (N/A) I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
