### PR TITLE
add sanitizing out the nested mx-reply

### DIFF
--- a/src/app/utils/sanitize.ts
+++ b/src/app/utils/sanitize.ts
@@ -140,7 +140,15 @@ export const sanitizeCustomHtml = (customHtml: string): string =>
     nestingLimit: MAX_TAG_NESTING,
   });
 
-export const sanitizeText = (body: string) => {
+export const sanitizeText = (contentbody: string) => {
+
+  //split out nested replies
+  let splitcontentbody = contentbody.split("</mx-reply>")
+
+  //grab only the new content from the message you are quoting, not the nested replies
+  let body = splitcontentbody[splitcontentbody.length - 1]
+
+  //tags to regex out (???)
   const tagsToReplace: Record<string, string> = {
     '&': '&amp;',
     '<': '&lt;',
@@ -148,5 +156,7 @@ export const sanitizeText = (body: string) => {
     '"': '&quot;',
     "'": '&#39;',
   };
+
+  //regex out tags  
   return body.replace(/[&<>'"]/g, (tag) => tagsToReplace[tag] || tag);
 };


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # removes the nested mxreply in the message you're quoting so that it doesnt make it apart of message body. this is due to the reply removing the nested `<mx-reply>` but not the `</mx-reply>` causing it to end the html tag early
![image](https://github.com/cinnyapp/cinny/assets/94018608/38dc278c-c7a2-4080-bc80-8809ed0f819d)
![image](https://github.com/cinnyapp/cinny/assets/94018608/a1c1f0bc-bb61-463f-aa2e-f79c5aef1ebe)

probably need to change it to make it typescript, i only know js. im praying that this works fine just popping in js.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
