### PR TITLE
Make small images not scale up in image viewer

### DIFF
--- a/src/app/components/image-viewer/ImageViewer.css.ts
+++ b/src/app/components/image-viewer/ImageViewer.css.ts
@@ -32,8 +32,10 @@ export const ImageViewerImg = style([
   DefaultReset,
   {
     objectFit: 'contain',
-    width: '100%',
-    height: '100%',
+    width: 'auto',
+    height: 'auto',
+    maxWidth: '100%',
+    maxHeight: '100%',
     backgroundColor: color.Surface.Container,
     transition: 'transform 100ms linear',
   },


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Makes small images not scale up in image viewer, (when you click an image) instead show them in real resolution, especially good improvement for extra small images and pixel art.

before: ![image was always scaled up](https://wfr.moe/f6KpEo.png)

after: ![image now in original resolution](https://wfr.moe/f6KCC5.png)

(note one is current stable release, other is master, so other things might be slightly different in the screenshots)

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas - n/a
- [ ] I have made corresponding changes to the documentation - n/a
- [x] My changes generate no new warnings
