### PR TITLE
make small attachments not scale in timeline

### DIFF
--- a/src/app/organisms/room/RoomTimeline.tsx
+++ b/src/app/organisms/room/RoomTimeline.tsx
@@ -1141,7 +1141,9 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
       const dim = scaleDimension(videoInfo.w || 400, videoInfo.h || 400, 48, 48, 400, 600);
 
       return (
-        <Attachment>
+        <Attachment style={{
+          width: toRem(dim.w)
+        }}>
           <AttachmentBox
             style={{
               width: toRem(dim.w),

--- a/src/app/organisms/room/RoomTimeline.tsx
+++ b/src/app/organisms/room/RoomTimeline.tsx
@@ -101,7 +101,7 @@ import {
   selectTab,
 } from '../../../client/action/navigation';
 import { useForceUpdate } from '../../hooks/useForceUpdate';
-import { parseGeoUri, scaleYDimension } from '../../utils/common';
+import { parseGeoUri, scaleDimension } from '../../utils/common';
 import { useMatrixEventRenderer } from '../../hooks/useMatrixEventRenderer';
 import { useRoomMsgContentRenderer } from '../../hooks/useRoomMsgContentRenderer';
 import { IAudioContent, IImageContent, IVideoContent } from '../../../types/matrix/common';
@@ -1100,13 +1100,16 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
       if (typeof mxcUrl !== 'string') {
         return null;
       }
-      const height = scaleYDimension(imgInfo?.w || 400, 400, imgInfo?.h || 400);
+      const dim = scaleDimension(imgInfo?.w || 400, imgInfo?.h || 400, 400, 32, 600, 32);
 
       return (
-        <Attachment>
+        <Attachment style={{
+          width: toRem(dim.w)
+        }}>
           <AttachmentBox
             style={{
-              height: toRem(height < 48 ? 48 : height),
+              width: toRem(dim.w),
+              height: toRem(dim.h),
             }}
           >
             <ImageContent
@@ -1135,13 +1138,14 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
         return null;
       }
 
-      const height = scaleYDimension(videoInfo.w || 400, 400, videoInfo.h || 400);
+      const dim = scaleDimension(videoInfo.w || 400, videoInfo.h || 400, 400, 48, 600, 48);
 
       return (
         <Attachment>
           <AttachmentBox
             style={{
-              height: toRem(height < 48 ? 48 : height),
+              width: toRem(dim.w),
+              height: toRem(dim.h),
             }}
           >
             <VideoContent

--- a/src/app/organisms/room/RoomTimeline.tsx
+++ b/src/app/organisms/room/RoomTimeline.tsx
@@ -1100,7 +1100,7 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
       if (typeof mxcUrl !== 'string') {
         return null;
       }
-      const dim = scaleDimension(imgInfo?.w || 400, imgInfo?.h || 400, 400, 32, 600, 32);
+      const dim = scaleDimension(imgInfo?.w || 400, imgInfo?.h || 400, 32, 32, 400, 600);
 
       return (
         <Attachment style={{
@@ -1138,7 +1138,7 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
         return null;
       }
 
-      const dim = scaleDimension(videoInfo.w || 400, videoInfo.h || 400, 400, 48, 600, 48);
+      const dim = scaleDimension(videoInfo.w || 400, videoInfo.h || 400, 48, 48, 400, 600);
 
       return (
         <Attachment>

--- a/src/app/organisms/room/message/StickerContent.tsx
+++ b/src/app/organisms/room/message/StickerContent.tsx
@@ -23,7 +23,7 @@ export const StickerContent = as<'div', StickerContentProps>(
     if (typeof mxcUrl !== 'string') {
       return <MessageBrokenContent />;
     }
-    const scaled = scaleDimension(imgInfo?.w || 152, imgInfo?.h || 152, 152, 16, 152, 16);
+    const scaled = scaleDimension(imgInfo?.w || 152, imgInfo?.h || 152, 16, 16, 152, 152);
 
     return (
       <AttachmentBox

--- a/src/app/organisms/room/message/StickerContent.tsx
+++ b/src/app/organisms/room/message/StickerContent.tsx
@@ -7,7 +7,7 @@ import {
   MessageDeletedContent,
 } from '../../../components/message';
 import { ImageContent } from './ImageContent';
-import { scaleYDimension } from '../../../utils/common';
+import { scaleDimension } from '../../../utils/common';
 import { IImageContent } from '../../../../types/matrix/common';
 
 type StickerContentProps = {
@@ -23,13 +23,13 @@ export const StickerContent = as<'div', StickerContentProps>(
     if (typeof mxcUrl !== 'string') {
       return <MessageBrokenContent />;
     }
-    const height = scaleYDimension(imgInfo?.w || 152, 152, imgInfo?.h || 152);
+    const scaled = scaleDimension(imgInfo?.w || 152, imgInfo?.h || 152, 152, 16, 152, 16);
 
     return (
       <AttachmentBox
         style={{
-          height: toRem(height < 48 ? 48 : height),
-          width: toRem(152),
+          height: toRem(scaled.h),
+          width: toRem(scaled.w),
         }}
         {...props}
         ref={ref}

--- a/src/app/organisms/room/msgContent.ts
+++ b/src/app/organisms/room/msgContent.ts
@@ -53,7 +53,7 @@ export const getImageMsgContent = async (
     body: file.name,
   };
   if (imgEl) {
-    const dim = scaleDimension(imgEl.width, imgEl.height, 512, 32, 512, 32);
+    const dim = scaleDimension(imgEl.width, imgEl.height, 32, 32, 512, 512);
     const blurHash = encodeBlurHash(imgEl, dim.w, dim.h);
 
     content.info = {
@@ -96,7 +96,7 @@ export const getVideoMsgContent = async (
       )
     );
     if (thumbContent && thumbContent.thumbnail_info) {
-      const dim = scaleDimension(videoEl.width, videoEl.height, 512, 32, 512, 32);
+      const dim = scaleDimension(videoEl.width, videoEl.height, 32, 32, 512, 512);
       thumbContent.thumbnail_info[MATRIX_BLUR_HASH_PROPERTY_NAME] = encodeBlurHash(
         videoEl,
         dim.w,

--- a/src/app/organisms/room/msgContent.ts
+++ b/src/app/organisms/room/msgContent.ts
@@ -12,7 +12,7 @@ import {
 import { encryptFile, getImageInfo, getThumbnailContent, getVideoInfo } from '../../utils/matrix';
 import { TUploadItem } from '../../state/roomInputDrafts';
 import { encodeBlurHash } from '../../utils/blurHash';
-import { scaleYDimension } from '../../utils/common';
+import { scaleDimension } from '../../utils/common';
 
 const generateThumbnailContent = async (
   mx: MatrixClient,
@@ -53,7 +53,8 @@ export const getImageMsgContent = async (
     body: file.name,
   };
   if (imgEl) {
-    const blurHash = encodeBlurHash(imgEl, 512, scaleYDimension(imgEl.width, 512, imgEl.height));
+    const dim = scaleDimension(imgEl.width, imgEl.height, 512, 32, 512, 32);
+    const blurHash = encodeBlurHash(imgEl, dim.w, dim.h);
 
     content.info = {
       ...getImageInfo(imgEl, file),
@@ -95,10 +96,11 @@ export const getVideoMsgContent = async (
       )
     );
     if (thumbContent && thumbContent.thumbnail_info) {
+      const dim = scaleDimension(videoEl.width, videoEl.height, 512, 32, 512, 32);
       thumbContent.thumbnail_info[MATRIX_BLUR_HASH_PROPERTY_NAME] = encodeBlurHash(
         videoEl,
-        512,
-        scaleYDimension(videoEl.videoWidth, 512, videoEl.videoHeight)
+        dim.w,
+        dim.h,
       );
     }
     if (thumbError) console.warn(thumbError);

--- a/src/app/utils/common.ts
+++ b/src/app/utils/common.ts
@@ -63,10 +63,17 @@ export const binarySearch = <T>(items: T[], match: (item: T) => -1 | 0 | 1): T |
 export const randomNumberBetween = (min: number, max: number) =>
   Math.floor(Math.random() * (max - min + 1)) + min;
 
-export const scaleYDimension = (x: number, scaledX: number, y: number): number => {
-  const scaleFactor = scaledX / x;
-  return scaleFactor * y;
-};
+export const scaleDimension = (x: number, y: number, maxX: number, minX: number = maxX, maxY: number = Infinity, minY: number = 0): {w: number, h: number} => {
+  let w = Math.max(minX, Math.min(maxX, x));
+  const scaleFactor = w / x;
+  let h = Math.max(minY, scaleFactor * y);
+  if (h > maxY) {
+    w = w / h * maxY;
+    h = maxY;
+  }
+  w = Math.max(minX, Math.min(maxX, w));
+  return { w, h };
+}
 
 export const parseGeoUri = (location: string) => {
   const [, data] = location.split(':');

--- a/src/app/utils/common.ts
+++ b/src/app/utils/common.ts
@@ -63,7 +63,7 @@ export const binarySearch = <T>(items: T[], match: (item: T) => -1 | 0 | 1): T |
 export const randomNumberBetween = (min: number, max: number) =>
   Math.floor(Math.random() * (max - min + 1)) + min;
 
-export const scaleDimension = (x: number, y: number, maxX: number, minX: number = maxX, maxY: number = Infinity, minY: number = 0): {w: number, h: number} => {
+export const scaleDimension = (x: number, y: number, minX: number, minY: number, maxX: number, maxY: number): {w: number, h: number} => {
   let w = Math.max(minX, Math.min(maxX, x));
   const scaleFactor = w / x;
   let h = Math.max(minY, scaleFactor * y);

--- a/src/app/utils/common.ts
+++ b/src/app/utils/common.ts
@@ -63,15 +63,15 @@ export const binarySearch = <T>(items: T[], match: (item: T) => -1 | 0 | 1): T |
 export const randomNumberBetween = (min: number, max: number) =>
   Math.floor(Math.random() * (max - min + 1)) + min;
 
-export const scaleDimension = (x: number, y: number, minX: number, minY: number, maxX: number, maxY: number): {w: number, h: number} => {
-  let w = Math.max(minX, Math.min(maxX, x));
-  const scaleFactor = w / x;
-  let h = Math.max(minY, scaleFactor * y);
-  if (h > maxY) {
-    w = w / h * maxY;
-    h = maxY;
+export const scaleDimension = (inW: number, inH: number, minW: number, minH: number, maxW: number, maxH: number): {w: number, h: number} => {
+  let w = Math.max(minW, Math.min(maxW, inW));
+  const scaleFactor = w / inW;
+  let h = Math.max(minH, scaleFactor * inH);
+  if (h > maxH) {
+    w = w / h * maxH;
+    h = maxH;
   }
-  w = Math.max(minX, Math.min(maxX, w));
+  w = Math.max(minW, Math.min(maxW, w));
   return { w, h };
 }
 


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

ultra wide / ultra tall but otherwise small images are cropped if too small in one dimension (minimum size changed to 32x32 in timeline for images, 48x48 for videos)

preview:

![example timeline](https://wfr.moe/f6KNlV.png)

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Design change

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas - n/a
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
