### PR TITLE
Scroll tab target into view

### DIFF
--- a/src/app/atoms/tabs/Tabs.jsx
+++ b/src/app/atoms/tabs/Tabs.jsx
@@ -41,8 +41,9 @@ TabItem.propTypes = {
 function Tabs({ items, defaultSelected, onSelect }) {
   const [selectedItem, setSelectedItem] = useState(items[defaultSelected]);
 
-  const handleTabSelection = (item, index) => {
+  const handleTabSelection = (item, index, target) => {
     if (selectedItem === item) return;
+    target.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
     setSelectedItem(item);
     onSelect(item, index);
   };
@@ -57,7 +58,7 @@ function Tabs({ items, defaultSelected, onSelect }) {
               selected={selectedItem.text === item.text}
               iconSrc={item.iconSrc}
               disabled={item.disabled}
-              onClick={() => handleTabSelection(item, index)}
+              onClick={(e) => handleTabSelection(item, index, e.currentTarget)}
             >
               {item.text}
             </TabItem>


### PR DESCRIPTION
### Description

Clicking a tab on mobile does not look very good.
Scroll the target into view (center) to see it clearly as well as following tabs

![image](https://github.com/cinnyapp/cinny/assets/33117017/bcbfbd16-d7f3-48d7-a2c0-19a310c41f90)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
