### PR TITLE
Fix context menu being hidden on mobile

### DIFF
--- a/src/app/molecules/room-selector/RoomSelector.scss
+++ b/src/app/molecules/room-selector/RoomSelector.scss
@@ -19,7 +19,7 @@
     }
   }
   
-  &--selected {
+  &--selected.room-selector {
     background-color: var(--bg-surface);
     border-color: var(--bg-surface-border);
 
@@ -28,7 +28,15 @@
     }
   }
 
+  & .room-selector__options {
+    display: flex;
+  }
+
   @media (hover: hover) {
+    & .room-selector__options {
+      display: none;
+    }
+
     &:hover {
       background-color: var(--bg-surface-hover);
       & .room-selector__options {

--- a/src/app/organisms/navigation/Selector.jsx
+++ b/src/app/organisms/navigation/Selector.jsx
@@ -44,7 +44,7 @@ function Selector({
   const openOptions = (e) => {
     e.preventDefault();
     openReusableContextMenu(
-      'right',
+      window.innerWidth <= 750 ? 'bottom' : 'right',
       getEventCords(e, '.room-selector'),
       room.isSpaceRoom()
         ? (closeMenu) => <SpaceOptions roomId={roomId} afterOptionSelect={closeMenu} />

--- a/src/app/organisms/room/RoomViewHeader.scss
+++ b/src/app/organisms/room/RoomViewHeader.scss
@@ -33,7 +33,7 @@
   }
 }
 .room-header__members-btn {
-  @include screen.biggerThan(tabletBreakpoint) {
+  @include screen.biggerEqualsThan(tabletBreakpoint) {
     display: none;
   }
 }
@@ -41,7 +41,7 @@
 .room-header__back-btn {
   @include dir.side(margin, 0, var(--sp-tight));
 
-  @include screen.biggerThan(mobileBreakpoint) {
+  @include screen.biggerEqualsThan(mobileBreakpoint) {
     display: none;
   }
 }

--- a/src/app/partials/_screen.scss
+++ b/src/app/partials/_screen.scss
@@ -15,13 +15,13 @@ $breakpoint-mobile: 750px;
   }
 }
 
-@mixin biggerThan($deviceBreakpoint) {
+@mixin biggerEqualsThan($deviceBreakpoint) {
   @if $deviceBreakpoint==mobileBreakpoint {
-    @media screen and (min-width: $breakpoint-mobile) {
+    @media screen and (min-width: ($breakpoint-mobile + 1)) {
       @content;
     }
   } @else if $deviceBreakpoint==tabletBreakpoint {
-    @media screen and (min-width: $breakpoint-tablet) {
+    @media screen and (min-width: ($breakpoint-tablet + 1)) {
       @content;
     }
   }


### PR DESCRIPTION
### Description

Room context Menu is not visible on mobile as it is rendered off screen to the right.
Also show selection options on devices without hover.

Also the back button is not visible on 750px width and members toggle on 1124px

![image](https://github.com/cinnyapp/cinny/assets/33117017/1c564fb5-e7ca-4708-9f17-db62b785e710)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
