### PR TITLE
Load assets from relative path

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,52 +6,52 @@
   "lang": "en-US",
   "display": "standalone",
   "orientation": "portrait",
-  "start_url": "/",
+  "start_url": "./",
   "background_color": "#fff",
   "theme_color": "#fff",
   "icons": [
     {
-      "src": "/public/android/android-chrome-36x36.png",
+      "src": "./public/android/android-chrome-36x36.png",
       "sizes": "36x36",
       "type": "image/png"
     },
     {
-      "src": "/public/android/android-chrome-48x48.png",
+      "src": "./public/android/android-chrome-48x48.png",
       "sizes": "48x48",
       "type": "image/png"
     },
     {
-      "src": "/public/android/android-chrome-72x72.png",
+      "src": "./public/android/android-chrome-72x72.png",
       "sizes": "72x72",
       "type": "image/png"
     },
     {
-      "src": "/public/android/android-chrome-96x96.png",
+      "src": "./public/android/android-chrome-96x96.png",
       "sizes": "96x96",
       "type": "image/png"
     },
     {
-      "src": "/public/android/android-chrome-144x144.png",
+      "src": "./public/android/android-chrome-144x144.png",
       "sizes": "144x144",
       "type": "image/png"
     },
     {
-      "src": "/public/android/android-chrome-192x192.png",
+      "src": "./public/android/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/public/android/android-chrome-256x256.png",
+      "src": "./public/android/android-chrome-256x256.png",
       "sizes": "256x256",
       "type": "image/png"
     },
     {
-      "src": "/public/android/android-chrome-384x384.png",
+      "src": "./public/android/android-chrome-384x384.png",
       "sizes": "384x384",
       "type": "image/png"
     },
     {
-      "src": "/public/android/android-chrome-512x512.png",
+      "src": "./public/android/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/src/app/plugins/pdfjs-dist.ts
+++ b/src/app/plugins/pdfjs-dist.ts
@@ -7,7 +7,7 @@ export const usePdfJSLoader = () =>
   useAsyncCallback(
     useCallback(async () => {
       const pdf = await import('pdfjs-dist');
-      pdf.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';
+      pdf.GlobalWorkerOptions.workerSrc = 'pdf.worker.min.js';
       return pdf;
     }, [])
   );


### PR DESCRIPTION
### Description

Deploying cinny on a sub path like `/cinny/` breaks loading of some assets.
Use relative path to prevent 404s.

- rendering PDFs
- web app manifest
- web app icons
- web app start

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
