### PR TITLE
make blurhash a bit less punchy in light themes

### DIFF
--- a/src/app/organisms/room/message/ImageContent.tsx
+++ b/src/app/organisms/room/message/ImageContent.tsx
@@ -99,7 +99,11 @@ export const ImageContent = as<'div', ImageContentProps>(
         )}
         {typeof blurHash === 'string' && !load && (
           <BlurhashCanvas
-            style={{ width: '100%', height: '100%' }}
+            style={{
+              width: '100%',
+              height: '100%',
+              filter: 'contrast(80%) invert(100%) brightness(0.75) invert(100%)'
+            }}
             width={32}
             height={32}
             hash={blurHash}

--- a/src/app/organisms/room/message/ImageContent.tsx
+++ b/src/app/organisms/room/message/ImageContent.tsx
@@ -102,7 +102,7 @@ export const ImageContent = as<'div', ImageContentProps>(
             style={{
               width: '100%',
               height: '100%',
-              filter: 'contrast(80%) invert(100%) brightness(0.75) invert(100%)'
+              filter: 'var(--blurhash-filter)'
             }}
             width={32}
             height={32}

--- a/src/app/organisms/room/message/VideoContent.tsx
+++ b/src/app/organisms/room/message/VideoContent.tsx
@@ -92,7 +92,7 @@ export const VideoContent = as<'div', VideoContentProps>(
             style={{
               width: '100%',
               height: '100%',
-              filter: 'contrast(80%) invert(100%) brightness(0.75) invert(100%)'
+              filter: 'var(--blurhash-filter)'
             }}
             width={32}
             height={32}

--- a/src/app/organisms/room/message/VideoContent.tsx
+++ b/src/app/organisms/room/message/VideoContent.tsx
@@ -89,7 +89,11 @@ export const VideoContent = as<'div', VideoContentProps>(
       <Box className={classNames(css.RelativeBase, className)} {...props} ref={ref}>
         {typeof blurHash === 'string' && !load && (
           <BlurhashCanvas
-            style={{ width: '100%', height: '100%' }}
+            style={{
+              width: '100%',
+              height: '100%',
+              filter: 'contrast(80%) invert(100%) brightness(0.75) invert(100%)'
+            }}
             width={32}
             height={32}
             hash={blurHash}

--- a/src/index.scss
+++ b/src/index.scss
@@ -181,6 +181,8 @@
 
   --popup-window-drawer-width: 280px;
 
+  --blurhash-filter: contrast(80%) invert(100%) brightness(0.75) invert(100%);
+
   @include screen.smallerThan(tabletBreakpoint) {
     --navigation-drawer-width: calc(240px + var(--border-width));
     --people-drawer-width: calc(256px - var(--border-width));
@@ -295,6 +297,9 @@
   --fw-bold: 550;
 
   --font-secondary: 'InterVariable', var(--font-emoji), sans-serif;
+
+  /* other */
+  --blurhash-filter: none;
 }
 
 .butter-theme {


### PR DESCRIPTION
Just a design change. The punch argument didn't seem to give good results, so I implemented it using a CSS filter now.

This change only applies to the light themes.

Mostly affects people that have media auto-loading disabled or while loading full images.

<table>
<tr>
 <th>Before
 <th>After
 <th>Image
<tr>
 <td>

![image](https://wfr.moe/f6MaWw.png)

 <td>

![image](https://wfr.moe/f6MMYU.png)

 <td>

![image](https://wfr.moe/f6n8Rr.png)

<tr>
 <td>

![image](https://wfr.moe/f6MXyF.png)

 <td>

![image](https://wfr.moe/f6MMhf.png)

 <td>

![image](https://wfr.moe/f6ngAx.png)

<tr>
 <td>

![image](https://wfr.moe/f6MXqU.png)

 <td>

![image](https://wfr.moe/f6Mn1W.png)

 <td>

![image](https://wfr.moe/f6nvOa.png)

<tr>
 <td>

![image](https://wfr.moe/f6nOCE.png)

 <td>

![image](https://wfr.moe/f6MkGX.png)

 <td>

![image](https://wfr.moe/f6nvTV.png)

<tr>
 <td>

![image](https://wfr.moe/f6n6tB.png)

 <td>

![image](https://wfr.moe/f6MkaD.png)

 <td>

![image](https://wfr.moe/f6nyQl.png)

<tr>
 <td>

![image](https://wfr.moe/f6n6Mg.png)

 <td>

![image](https://wfr.moe/f6MerI.png)

 <td>

![image](https://wfr.moe/f6nj4n.png)

</table>

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
