### PR TITLE
remove 0.05em padding from emoji

### DIFF
--- a/src/app/styles/CustomHtml.css.ts
+++ b/src/app/styles/CustomHtml.css.ts
@@ -171,7 +171,6 @@ export const EmoticonBase = style([
   DefaultReset,
   {
     display: 'inline-block',
-    padding: '0.05rem',
     height: '1em',
     verticalAlign: 'middle',
   },


### PR DESCRIPTION
seems completely random and breaks chaining multiple custom emoji together in a row, as well as not being aligned to pixels.

before:

![emoji chain](https://wfr.moe/f6nEQh.png)

after:

![emoji chain](https://wfr.moe/f6nPuv.png)
