### PR TITLE
Fix avatar in room header on bridge-created rooms

### DIFF
--- a/src/app/organisms/room/RoomViewHeader.jsx
+++ b/src/app/organisms/room/RoomViewHeader.jsx
@@ -40,10 +40,8 @@ function RoomViewHeader({ roomId }) {
   const isDM = initMatrix.roomList.directs.has(roomId);
   const room = mx.getRoom(roomId);
   const setPeopleDrawer = useSetSetting(settingsAtom, 'isPeopleDrawer');
-  let avatarSrc = room.getAvatarUrl(mx.baseUrl, 36, 36, 'crop');
-  avatarSrc = isDM
-    ? room.getAvatarFallbackMember()?.getAvatarUrl(mx.baseUrl, 36, 36, 'crop')
-    : avatarSrc;
+  let avatarSrc = room.getAvatarFallbackMember()?.getAvatarUrl(mx.baseUrl, 24, 24, 'crop') || null;
+  if (avatarSrc === null) avatarSrc = room.getAvatarUrl(mx.baseUrl, 36, 36, 'crop') || null;
   const roomName = room.name;
 
   const roomHeaderBtnRef = useRef(null);


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
This would always fallback to default avatar when usercount is more than 3 in direct message. It is not always the case, as the bridge created rooms have 3 people: You, the bridge, and the puppet that's sending the message.
```jsx
let avatarSrc = room.getAvatarUrl(mx.baseUrl, 36, 36, 'crop');
  avatarSrc = isDM
    ? room.getAvatarFallbackMember()?.getAvatarUrl(mx.baseUrl, 36, 36, 'crop')
    : avatarSrc;
```
I've replaced it to 
```jsx
let avatarSrc = room.getAvatarFallbackMember()?.getAvatarUrl(mx.baseUrl, 24, 24, 'crop') || null;
if (avatarSrc === null) avatarSrc = room.getAvatarUrl(mx.baseUrl, 36, 36, 'crop') || null;
```
Which is how avatar source is determined in drawer, where it is correct.

Fixes #1619

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
