### PR TITLE
Add (ctrl-)alt-up/down keyboard navigation

### DIFF
--- a/src/app/organisms/navigation/Directs.jsx
+++ b/src/app/organisms/navigation/Directs.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 
 import initMatrix from '../../../client/initMatrix';
@@ -10,7 +10,7 @@ import { roomIdByActivity } from '../../../util/sort';
 import RoomsCategory from './RoomsCategory';
 
 const drawerPostie = new Postie();
-function Directs({ size }) {
+const Directs = forwardRef(({ size }, ref) => {
   const mx = initMatrix.matrixClient;
   const { roomList, notifications } = initMatrix;
   const [directIds, setDirectIds] = useState([]);
@@ -62,8 +62,16 @@ function Directs({ size }) {
     };
   }, []);
 
-  return <RoomsCategory name="People" hideHeader roomIds={directIds} drawerPostie={drawerPostie} />;
-}
+  return (
+    <RoomsCategory
+      ref={ref}
+      name="People"
+      hideHeader
+      roomIds={directIds}
+      drawerPostie={drawerPostie}
+    />
+  );
+});
 Directs.propTypes = {
   size: PropTypes.number.isRequired,
 };

--- a/src/app/organisms/navigation/DrawerBreadcrumb.jsx
+++ b/src/app/organisms/navigation/DrawerBreadcrumb.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, forwardRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
 import './DrawerBreadcrumb.scss';
 
@@ -18,12 +18,24 @@ import NotificationBadge from '../../atoms/badge/NotificationBadge';
 
 import ChevronRightIC from '../../../../public/res/ic/outlined/chevron-right.svg';
 
-function DrawerBreadcrumb({ spaceId }) {
+const DrawerBreadcrumb = forwardRef(({ spaceId }, ref) => {
   const [, forceUpdate] = useState({});
   const scrollRef = useRef(null);
   const { roomList, notifications, accountData } = initMatrix;
   const mx = initMatrix.matrixClient;
   const spacePath = navigation.selectedSpacePath;
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      goUp() {
+        let id = spacePath[spacePath.length - 2];
+        if (id === cons.tabs.HOME) selectTab(id);
+        else selectSpace(id);
+      },
+    }),
+    [spacePath]
+  );
 
   function onNotiChanged(roomId, total, prevTotal) {
     if (total === prevTotal) return;
@@ -129,7 +141,7 @@ function DrawerBreadcrumb({ spaceId }) {
       </ScrollView>
     </div>
   );
-}
+});
 
 DrawerBreadcrumb.defaultProps = {
   spaceId: null,


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Using Alt-Up/Down moves up/down in the room list / DM list (the drawer)

Using Alt-Left moves up one breadcrumb in a breadcrumbed subspace.

Using Ctrl-Alt-Up/Down moves up/down the pinned spaces (the sidebar) or goes into home or DMs when at the top.

These shortcuts match some other popular messengers (e.g. partially telegram, fully discord, partially element)

Subspaces aren't working optimally yet, since they are immediately entered. In a follow-up PR I would like to improve on that so that they are only selected and not automatically visited when using keyboard navigation, however that requires some more changes I haven't looked into yet.

For navigation the lists or buttons implement imperative refs now. Lists implement a `hasSelected` for the parent to check on which element to start searching for the next item to focus, as well as a `navigate` method which takes in `0`, `1` or `-1`, meaning select current again, select next or select previous respectively. If navigate returns `0`, an item has been selected, if it returns non-zero it means we should continue searching in the adjacent list.

The drawer (home) and sidebar both have an instance of code that goes through a list of lists - could maybe deduplicate this, but without typescript it's a pain to maintain correctness as a public method so I'd rather not do that right now while these components still use plain JS.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
	- (ran prettier)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
