### PR TITLE
Do not display duplicate reactions

### DIFF
--- a/src/app/organisms/room/message/Reactions.tsx
+++ b/src/app/organisms/room/message/Reactions.tsx
@@ -37,7 +37,19 @@ export const Reactions = as<'div', ReactionsProps>(
     const reactions = useRelations(
       relations,
       useCallback((rel) => [...(rel.getSortedAnnotationsByKey() ?? [])], [])
-    );
+    ).map((reaction) => {
+      // Multiple reactions with same user & key may exist
+      // so only show one of them
+      const events = Array.from(reaction[1]);
+      // eslint-disable-next-line no-param-reassign
+      reaction[1] = new Set(
+        events.filter(
+          (event, index) =>
+            events.findIndex((e) => e.sender?.userId === event.sender?.userId) === index
+        )
+      );
+      return reaction;
+    });
 
     const handleViewReaction: MouseEventHandler<HTMLButtonElement> = (evt) => {
       evt.stopPropagation();

--- a/src/app/organisms/room/reaction-viewer/ReactionViewer.tsx
+++ b/src/app/organisms/room/reaction-viewer/ReactionViewer.tsx
@@ -40,7 +40,19 @@ export const ReactionViewer = as<'div', ReactionViewerProps>(
     const reactions = useRelations(
       relations,
       useCallback((rel) => [...(rel.getSortedAnnotationsByKey() ?? [])], [])
-    );
+    ).map((reaction) => {
+      // Multiple reactions with same user & key may exist
+      // so only show one of them
+      const events = Array.from(reaction[1]);
+      // eslint-disable-next-line no-param-reassign
+      reaction[1] = new Set(
+        events.filter(
+          (event, index) =>
+            events.findIndex((e) => e.sender?.userId === event.sender?.userId) === index
+        )
+      );
+      return reaction;
+    });
 
     const [selectedKey, setSelectedKey] = useState<string>(() => {
       if (initialKey) return initialKey;


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
"Duplicate reactions" in this context means **reactions using the same key from the same user**

As there are two places in the code from where reactions can be gotten (`Reactions.tsx` & `ReactionViewer.tsx`), the code to fix the problem also appears twice
This code ignores (disables for a line) the `no-param-reassign` ESLint rule, as I couldn't find a way to return something of type `[string, Set<MatrixEvent>]` without returning the parameter itself

I must admit I don't really know if that's the right way to go about it

Fixes #1653

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
