### PR TITLE
Add setting to enable 24-hour time format

### DIFF
--- a/src/app/components/message/Time.tsx
+++ b/src/app/components/message/Time.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Text, as } from 'folds';
 import { timeDayMonYear, timeHourMinute, today, yesterday } from '../../utils/time';
+import { useSetting } from '../../state/hooks/settings';
+import { settingsAtom } from '../../state/settings';
 
 export type TimeProps = {
   compact?: boolean;
@@ -8,15 +10,19 @@ export type TimeProps = {
 };
 
 export const Time = as<'span', TimeProps>(({ compact, ts, ...props }, ref) => {
+  const [useInternationalTime] = useSetting(settingsAtom, 'useInternationalTime');
+  const formattedTime = timeHourMinute(ts, useInternationalTime);
+
   let time = '';
+
   if (compact) {
-    time = timeHourMinute(ts);
+    time = formattedTime;
   } else if (today(ts)) {
-    time = timeHourMinute(ts);
+    time = formattedTime;
   } else if (yesterday(ts)) {
-    time = `Yesterday ${timeHourMinute(ts)}`;
+    time = `Yesterday ${formattedTime}`;
   } else {
-    time = `${timeDayMonYear(ts)} ${timeHourMinute(ts)}`;
+    time = `${timeDayMonYear(ts)} ${formattedTime}`;
   }
 
   return (

--- a/src/app/components/message/Time.tsx
+++ b/src/app/components/message/Time.tsx
@@ -10,8 +10,8 @@ export type TimeProps = {
 };
 
 export const Time = as<'span', TimeProps>(({ compact, ts, ...props }, ref) => {
-  const [useInternationalTime] = useSetting(settingsAtom, 'useInternationalTime');
-  const formattedTime = timeHourMinute(ts, useInternationalTime);
+  const [hour24Clock] = useSetting(settingsAtom, 'hour24Clock');
+  const formattedTime = timeHourMinute(ts, hour24Clock);
 
   let time = '';
 

--- a/src/app/components/room-intro/RoomIntro.tsx
+++ b/src/app/components/room-intro/RoomIntro.tsx
@@ -9,6 +9,8 @@ import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { getMxIdLocalPart } from '../../utils/matrix';
 import { AsyncStatus, useAsyncCallback } from '../../hooks/useAsyncCallback';
 import { timeDayMonthYear, timeHourMinute } from '../../utils/time';
+import { useSetting } from '../../state/hooks/settings';
+import { settingsAtom } from '../../state/settings';
 
 export type RoomIntroProps = {
   room: Room;
@@ -35,6 +37,8 @@ export const RoomIntro = as<'div', RoomIntroProps>(({ room, ...props }, ref) => 
   const [prevRoomState, joinPrevRoom] = useAsyncCallback(
     useCallback(async (roomId: string) => mx.joinRoom(roomId), [mx])
   );
+
+  const [useInternationalTime] = useSetting(settingsAtom, 'useInternationalTime');
 
   return (
     <Box direction="Column" grow="Yes" gap="500" {...props} ref={ref}>
@@ -66,7 +70,7 @@ export const RoomIntro = as<'div', RoomIntroProps>(({ room, ...props }, ref) => 
             <Text size="T200" priority="300">
               {'Created by '}
               <b>@{creatorName}</b>
-              {` on ${timeDayMonthYear(ts)} ${timeHourMinute(ts)}`}
+              {` on ${timeDayMonthYear(ts)} ${timeHourMinute(ts, useInternationalTime)}`}
             </Text>
           )}
         </Box>

--- a/src/app/components/room-intro/RoomIntro.tsx
+++ b/src/app/components/room-intro/RoomIntro.tsx
@@ -38,7 +38,7 @@ export const RoomIntro = as<'div', RoomIntroProps>(({ room, ...props }, ref) => 
     useCallback(async (roomId: string) => mx.joinRoom(roomId), [mx])
   );
 
-  const [useInternationalTime] = useSetting(settingsAtom, 'useInternationalTime');
+  const [hour24Clock] = useSetting(settingsAtom, 'hour24Clock');
 
   return (
     <Box direction="Column" grow="Yes" gap="500" {...props} ref={ref}>
@@ -70,7 +70,7 @@ export const RoomIntro = as<'div', RoomIntroProps>(({ room, ...props }, ref) => 
             <Text size="T200" priority="300">
               {'Created by '}
               <b>@{creatorName}</b>
-              {` on ${timeDayMonthYear(ts)} ${timeHourMinute(ts, useInternationalTime)}`}
+              {` on ${timeDayMonthYear(ts)} ${timeHourMinute(ts, hour24Clock)}`}
             </Text>
           )}
         </Box>

--- a/src/app/organisms/settings/Settings.jsx
+++ b/src/app/organisms/settings/Settings.jsx
@@ -62,6 +62,11 @@ function AppearanceSection() {
   const [urlPreview, setUrlPreview] = useSetting(settingsAtom, 'urlPreview');
   const [encUrlPreview, setEncUrlPreview] = useSetting(settingsAtom, 'encUrlPreview');
   const [showHiddenEvents, setShowHiddenEvents] = useSetting(settingsAtom, 'showHiddenEvents');
+  const [useInternationalTime, setInternationalTime] = useSetting(
+    settingsAtom,
+    'useInternationalTime'
+  );
+  
   const spacings = ['0', '100', '200', '300', '400', '500']
 
   return (
@@ -222,6 +227,16 @@ function AppearanceSection() {
             />
           )}
           content={<Text variant="b3">Show hidden state and message events.</Text>}
+        />
+        <SettingTile
+          title="Use 24-hour time"
+          options={
+            <Toggle
+              isActive={useInternationalTime}
+              onToggle={() => setInternationalTime(!useInternationalTime)}
+            />
+          }
+          content={<Text variant="b3">Use the 24-hour time format for all timestamps.</Text>}
         />
       </div>
     </div>

--- a/src/app/organisms/settings/Settings.jsx
+++ b/src/app/organisms/settings/Settings.jsx
@@ -62,10 +62,7 @@ function AppearanceSection() {
   const [urlPreview, setUrlPreview] = useSetting(settingsAtom, 'urlPreview');
   const [encUrlPreview, setEncUrlPreview] = useSetting(settingsAtom, 'encUrlPreview');
   const [showHiddenEvents, setShowHiddenEvents] = useSetting(settingsAtom, 'showHiddenEvents');
-  const [useInternationalTime, setInternationalTime] = useSetting(
-    settingsAtom,
-    'useInternationalTime'
-  );
+  const [hour24Clock, setHour24Clock] = useSetting(settingsAtom, 'hour24Clock');
   
   const spacings = ['0', '100', '200', '300', '400', '500']
 
@@ -232,8 +229,8 @@ function AppearanceSection() {
           title="Use 24-hour time"
           options={
             <Toggle
-              isActive={useInternationalTime}
-              onToggle={() => setInternationalTime(!useInternationalTime)}
+              isActive={hour24Clock}
+              onToggle={() => setHour24Clock(!hour24Clock)}
             />
           }
           content={<Text variant="b3">Use the 24-hour time format for all timestamps.</Text>}

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -25,6 +25,8 @@ export interface Settings {
 
   showNotifications: boolean;
   isNotificationSounds: boolean;
+
+  useInternationalTime: boolean;
 }
 
 const defaultSettings: Settings = {
@@ -48,6 +50,8 @@ const defaultSettings: Settings = {
 
   showNotifications: true,
   isNotificationSounds: true,
+
+  useInternationalTime: false,
 };
 
 export const getSettings = () => {

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -26,7 +26,7 @@ export interface Settings {
   showNotifications: boolean;
   isNotificationSounds: boolean;
 
-  useInternationalTime: boolean;
+  hour24Clock: boolean;
 }
 
 const defaultSettings: Settings = {
@@ -51,7 +51,7 @@ const defaultSettings: Settings = {
   showNotifications: true,
   isNotificationSounds: true,
 
-  useInternationalTime: false,
+  hour24Clock: false,
 };
 
 export const getSettings = () => {

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -9,7 +9,8 @@ export const today = (ts: number): boolean => dayjs(ts).isToday();
 
 export const yesterday = (ts: number): boolean => dayjs(ts).isYesterday();
 
-export const timeHourMinute = (ts: number): string => dayjs(ts).format('hh:mm A');
+export const timeHourMinute = (ts: number, international: boolean = false): string =>
+  dayjs(ts).format(international ? 'HH:mm' : 'hh:mm A');
 
 export const timeDayMonYear = (ts: number): string => dayjs(ts).format('D MMM YYYY');
 

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -9,8 +9,8 @@ export const today = (ts: number): boolean => dayjs(ts).isToday();
 
 export const yesterday = (ts: number): boolean => dayjs(ts).isYesterday();
 
-export const timeHourMinute = (ts: number, international: boolean = false): string =>
-  dayjs(ts).format(international ? 'HH:mm' : 'hh:mm A');
+export const timeHourMinute = (ts: number, hour24Clock: boolean = false): string =>
+  dayjs(ts).format(hour24Clock ? 'HH:mm' : 'hh:mm A');
 
 export const timeDayMonYear = (ts: number): string => dayjs(ts).format('D MMM YYYY');
 


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Support for the 24-hour time format has been a frequently requested feature in the Cinny Matrix room and has been mentioned in multiple issues: #60, #1333, #1549, #1648. This PR adds a toggle in the settings page that allows the user to switch between 12-hour and 24-hour time formats.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
