### PR TITLE
Fix IPv6 support for the Docker container 

### DIFF
--- a/docker-nginx.conf
+++ b/docker-nginx.conf
@@ -1,8 +1,8 @@
 server {
   location / {
-		root /usr/share/nginx/html;
+    root /usr/share/nginx/html;
 
-		rewrite ^/config.json$ /config.json break;
+    rewrite ^/config.json$ /config.json break;
     rewrite ^/manifest.json$ /manifest.json break;
 
     rewrite ^.*/olm.wasm$ /olm.wasm break;
@@ -12,5 +12,5 @@ server {
     rewrite ^/assets/(.*)$ /assets/$1 break;
 
     rewrite ^(.+)$ /index.html break;
-	}
+  }
 }

--- a/docker-nginx.conf
+++ b/docker-nginx.conf
@@ -1,4 +1,7 @@
 server {
+  listen 80;
+  listen [::]:80;
+
   location / {
     root /usr/share/nginx/html;
 


### PR DESCRIPTION
### Description

#1837 introduced a new NGINX config for Docker inspired by the existing `contrib/nginx/cinny.domain.tld.conf`, but without the `listen [::]:80;` directive, which breaks the container for those that use IPv6.

This PR adds the IPv4 and IPv6 `listen` directives to make it work on both again. (I also reformatted the file to follow the project's style).

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
