### PR TITLE
Add prompt before sending invalid commands

### DIFF
--- a/src/app/components/editor/utils.ts
+++ b/src/app/components/editor/utils.ts
@@ -261,6 +261,17 @@ export const isEmptyEditor = (editor: Editor): boolean => {
   return false;
 };
 
+export const getAttemptedCommand = (editor: Editor): string | undefined => {
+  const lineBlock = editor.children[0];
+  if (!Element.isElement(lineBlock)) return undefined;
+  if (lineBlock.type !== BlockType.Paragraph) return undefined;
+
+  const [firstInline] = lineBlock.children;
+  const isCommand = Text.isText(firstInline) && firstInline.text[0] === '/';
+  if (isCommand) return firstInline.text.split(' ')[0];
+  return undefined;
+};
+
 export const getBeginCommand = (editor: Editor): string | undefined => {
   const lineBlock = editor.children[0];
   if (!Element.isElement(lineBlock)) return undefined;


### PR DESCRIPTION
### Description

This was previously a feature I added in #1435, but it got lost in a refactor. Here it is again.

When a message starts with `/` but didn't trigger a command, the popup will be shown. The popup allows sending it anyway, or going back to edit.

To make this work, I made the submit function async, which does not seem to have had any negative consequences.

This feature will prevent mistakes like this:

![image](https://github.com/user-attachments/assets/3a0fd348-7afe-413d-844d-4972138994a9)

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
