### PR TITLE
Fix download button

### DIFF
--- a/src/app/components/Pdf-viewer/PdfViewer.tsx
+++ b/src/app/components/Pdf-viewer/PdfViewer.tsx
@@ -27,6 +27,7 @@ import { AsyncStatus } from '../../hooks/useAsyncCallback';
 import { useZoom } from '../../hooks/useZoom';
 import { createPage, usePdfDocumentLoader, usePdfJSLoader } from '../../plugins/pdfjs-dist';
 import { stopPropagation } from '../../utils/keyboard';
+import { getSrcFile } from '../message/content/util';
 
 export type PdfViewerProps = {
   name: string;
@@ -78,7 +79,9 @@ export const PdfViewer = as<'div', PdfViewerProps>(
     }, [docState, pageNo, zoom]);
 
     const handleDownload = () => {
-      FileSaver.saveAs(src, name);
+      getSrcFile(src).then((blob) => {
+        FileSaver.saveAs(blob, name);
+      });
     };
 
     const handleJumpSubmit: FormEventHandler<HTMLFormElement> = (evt) => {

--- a/src/app/components/image-viewer/ImageViewer.tsx
+++ b/src/app/components/image-viewer/ImageViewer.tsx
@@ -6,6 +6,7 @@ import { Box, Chip, Header, Icon, IconButton, Icons, Text, as } from 'folds';
 import * as css from './ImageViewer.css';
 import { useZoom } from '../../hooks/useZoom';
 import { usePan } from '../../hooks/usePan';
+import { getSrcFile } from '../message/content/util';
 
 export type ImageViewerProps = {
   alt: string;
@@ -19,7 +20,9 @@ export const ImageViewer = as<'div', ImageViewerProps>(
     const { pan, cursor, onMouseDown } = usePan(zoom !== 1);
 
     const handleDownload = () => {
-      FileSaver.saveAs(src, alt);
+      getSrcFile(src).then((blob) => {
+        FileSaver.saveAs(blob, alt);
+      });
     };
 
     return (

--- a/src/app/components/message/content/FileContent.tsx
+++ b/src/app/components/message/content/FileContent.tsx
@@ -174,7 +174,11 @@ export function ReadPdfFile({ body, mimeType, url, encInfo, renderViewer }: Read
 
   const [pdfState, loadPdf] = useAsyncCallback(
     useCallback(async () => {
-      const httpUrl = await getFileSrcUrl(mxcUrlToHttp(mx, url, useAuthentication) ?? '', mimeType, encInfo);
+      const httpUrl = await getFileSrcUrl(
+        mxcUrlToHttp(mx, url, useAuthentication) ?? '',
+        mimeType,
+        encInfo
+      );
       setPdfViewer(true);
       return httpUrl;
     }, [mx, url, useAuthentication, mimeType, encInfo])
@@ -248,8 +252,13 @@ export function DownloadFile({ body, mimeType, url, info, encInfo }: DownloadFil
 
   const [downloadState, download] = useAsyncCallback(
     useCallback(async () => {
-      const httpUrl = await getFileSrcUrl(mxcUrlToHttp(mx, url, useAuthentication) ?? '', mimeType, encInfo);
-      FileSaver.saveAs(httpUrl, body);
+      const httpUrl = await getFileSrcUrl(
+        mxcUrlToHttp(mx, url, useAuthentication) ?? '',
+        mimeType,
+        encInfo
+      );
+      const httpSrc = httpUrl.startsWith('blob') ? httpUrl : await getSrcFile(httpUrl);
+      FileSaver.saveAs(httpSrc, body);
       return httpUrl;
     }, [mx, url, useAuthentication, mimeType, encInfo, body])
   );


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

Continuation of #1930, this time fix the download button.

Cinny uses `file-saver` to implment the download button, the `file-saver` implmentation has the following code:

https://github.com/eligrey/FileSaver.js/blob/5bb701bd6ea05a02836daf8ef88ec350a1dd4d83/src/FileSaver.js#L96-L98

which checks CORS using the following code:

https://github.com/eligrey/FileSaver.js/blob/5bb701bd6ea05a02836daf8ef88ec350a1dd4d83/src/FileSaver.js#L47-L55

In the earlier implmentation, `HEAD` request wasn't hooked, so when `file-saver` saves a file, it'll believe CORS request failed and try to open the URL in the browser tab, which won't work at all with authenicated media endpoints.

By hooking `HEAD` requests too, `file-saver` would properly save this file without opening a new tab.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
