### PR TITLE
Fix notifications not being sent on decryption correction

### DIFF
--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -204,7 +204,14 @@ function MessageNotifications() {
       const cachedUnreadInfo = unreadCacheRef.current.get(room.roomId);
       unreadCacheRef.current.set(room.roomId, unreadInfo);
 
-      if (unreadInfo.total === 0) return;
+      if (unreadInfo.total === 0) {
+        const handleUnreadEvent: RoomEventHandlerMap[RoomEvent.UnreadNotifications] = () => {
+          handleTimelineEvent(mEvent, room, toStartOfTimeline, removed, data);
+          room.removeListener(RoomEvent.UnreadNotifications, handleUnreadEvent);
+        };
+        room.on(RoomEvent.UnreadNotifications, handleUnreadEvent);
+        return;
+      }
       if (
         cachedUnreadInfo &&
         unreadEqual(unreadInfoToUnread(cachedUnreadInfo), unreadInfoToUnread(unreadInfo))


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #1892

My analysis in the issue actually seems to be wrong. The root cause for this issue is not the cache but the fact that the matrix-js-sdk sends a timeline event before calling the fixNotificationCountOnDecryption function (see https://github.com/matrix-org/matrix-js-sdk/blob/da044820d7d3255e41e403bfbd035bf7b90ddd6a/src/client.ts#L10322). This leads to the edge case that cinny returns in the sendTimelineEvent function as the counter is 0 before it is corrected to 1.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
