### PR TITLE
Invitations: show server part from inviter

### DIFF
--- a/src/app/pages/client/inbox/Invites.tsx
+++ b/src/app/pages/client/inbox/Invites.tsx
@@ -32,7 +32,12 @@ import {
 } from '../../../utils/room';
 import { nameInitials } from '../../../utils/common';
 import { RoomAvatar } from '../../../components/room-avatar';
-import { addRoomIdToMDirect, getMxIdLocalPart, guessDmRoomUserId } from '../../../utils/matrix';
+import {
+  addRoomIdToMDirect,
+  getMxIdLocalPart,
+  getMxIdServer,
+  guessDmRoomUserId,
+} from '../../../utils/matrix';
 import { Time } from '../../../components/message';
 import { useElementSizeObserver } from '../../../hooks/useElementSizeObserver';
 import { onEnterOrSpace, stopPropagation } from '../../../utils/keyboard';
@@ -64,6 +69,7 @@ function InviteCard({ room, userId, direct, compact, onNavigate }: InviteCardPro
   const senderName = senderId
     ? getMemberDisplayName(room, senderId) ?? getMxIdLocalPart(senderId) ?? senderId
     : undefined;
+  const serverName = senderId ? getMxIdServer(senderId) : undefined;
 
   const topic = useRoomTopic(room);
 
@@ -102,6 +108,12 @@ function InviteCard({ room, userId, direct, compact, onNavigate }: InviteCardPro
         <Box grow="Yes">
           <Text size="T200" priority="300" truncate>
             Invited by <b>{senderName}</b>
+            {serverName && (
+              <>
+                {' on '}
+                <b>{serverName}</b>
+              </>
+            )}
           </Text>
         </Box>
         <Box shrink="No">


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

The invitations list now shows "on **server.domain**" for whoever invited you:

![image](https://github.com/user-attachments/assets/3df92d44-ad1c-43b3-be57-d7fe043da226)

Some servers are particularly prone to spam users, this helps identifying spam invites early on.

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- n/a: I have commented my code, particularly in hard-to-understand areas
- n/a: I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
