### PR TITLE
Render captions to m.file, m.image, m.video, and m.audio

### DIFF
--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -69,24 +69,25 @@ export function RenderMessageContent({
     );
   };
   const content: IImageContent = getContent();
-  const renderCaption = content.filename && content.filename !== content.body;
-  let renderedCaption: React.ReactNode = null;
-  if(renderCaption) {
-    renderedCaption = (
-      <MNotice
-        edited={edited}
-        content={getContent()}
-        renderBody={(props) => (
-          <RenderBody
-            {...props}
-            highlightRegex={highlightRegex}
-            htmlReactParserOptions={htmlReactParserOptions}
-            linkifyOpts={linkifyOpts}
-          />
-        )}
-        renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
-      />
-    )
+  const renderCaption = () => {
+    if(content.filename && content.filename !== content.body) {
+      return (
+        <MText
+          edited={edited}
+          content={getContent()}
+          renderBody={(props) => (
+            <RenderBody
+              {...props}
+              highlightRegex={highlightRegex}
+              htmlReactParserOptions={htmlReactParserOptions}
+              linkifyOpts={linkifyOpts}
+            />
+          )}
+          renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
+        />
+      )
+    }
+    return null;
   }
 
   const renderFile = () => (
@@ -122,7 +123,7 @@ export function RenderMessageContent({
         )}
         outlined={outlineAttachment}
       />
-      {renderedCaption}
+      {renderCaption()}
     </>
   );
 
@@ -196,7 +197,7 @@ export function RenderMessageContent({
           )}
           outlined={outlineAttachment}
         />
-        {renderedCaption}
+        {renderCaption()}
       </>
     );
   }
@@ -231,7 +232,7 @@ export function RenderMessageContent({
           )}
           outlined={outlineAttachment}
         />
-        {renderedCaption}
+        {renderCaption()}
       </>
 
     );
@@ -248,7 +249,7 @@ export function RenderMessageContent({
           )}
           outlined={outlineAttachment}
         />
-        {renderedCaption}
+        {renderCaption()}
       </>
 
     );

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -68,13 +68,13 @@ export function RenderMessageContent({
       </UrlPreviewHolder>
     );
   };
-  const content: IImageContent = getContent();
   const renderCaption = () => {
+    const content: IImageContent = getContent();
     if(content.filename && content.filename !== content.body) {
       return (
         <MText
           edited={edited}
-          content={getContent()}
+          content={content}
           renderBody={(props) => (
             <RenderBody
               {...props}

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -29,6 +29,7 @@ import { ImageViewer } from './image-viewer';
 import { PdfViewer } from './Pdf-viewer';
 import { TextViewer } from './text-viewer';
 import { testMatrixTo } from '../plugins/matrix-to';
+import {IImageContent} from "../../types/matrix/common";
 
 type RenderMessageContentProps = {
   displayName: string;
@@ -157,19 +158,48 @@ export function RenderMessageContent({
   }
 
   if (msgType === MsgType.Image) {
+    const content: IImageContent = getContent();
+    const renderCaption = content.filename && content.filename !== content.body;
     return (
-      <MImage
-        content={getContent()}
-        renderImageContent={(props) => (
-          <ImageContent
-            {...props}
-            autoPlay={mediaAutoLoad}
-            renderImage={(p) => <Image {...p} loading="lazy" />}
-            renderViewer={(p) => <ImageViewer {...p} />}
-          />
-        )}
-        outlined={outlineAttachment}
-      />
+      <>
+        <MImage
+            content={getContent()}
+            renderBody={(props) => (
+                <RenderBody
+                    {...props}
+                    highlightRegex={highlightRegex}
+                    htmlReactParserOptions={htmlReactParserOptions}
+                    linkifyOpts={linkifyOpts}
+                />
+            )}
+            renderImageContent={(props) => (
+                <ImageContent
+                    {...props}
+                    autoPlay={mediaAutoLoad}
+                    renderImage={(p) => <Image {...p} loading="lazy" />}
+                    renderViewer={(p) => <ImageViewer {...p} />}
+                />
+            )}
+            outlined={outlineAttachment}
+        />
+        {
+          renderCaption && (
+                <MNotice
+                    edited={edited}
+                    content={getContent()}
+                    renderBody={(props) => (
+                        <RenderBody
+                            {...props}
+                            highlightRegex={highlightRegex}
+                            htmlReactParserOptions={htmlReactParserOptions}
+                            linkifyOpts={linkifyOpts}
+                        />
+                    )}
+                    renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
+                />
+            )
+        }
+      </>
     );
   }
 

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -164,14 +164,6 @@ export function RenderMessageContent({
       <>
         <MImage
           content={getContent()}
-          renderBody={(props) => (
-            <RenderBody
-                {...props}
-                highlightRegex={highlightRegex}
-                htmlReactParserOptions={htmlReactParserOptions}
-                linkifyOpts={linkifyOpts}
-            />
-          )}
           renderImageContent={(props) => (
               <ImageContent
                   {...props}

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -156,48 +156,48 @@ export function RenderMessageContent({
       />
     );
   }
+  const content: IImageContent = getContent();
+  const renderCaption = content.filename && content.filename !== content.body;
 
   if (msgType === MsgType.Image) {
-    const content: IImageContent = getContent();
-    const renderCaption = content.filename && content.filename !== content.body;
     return (
       <>
         <MImage
-            content={getContent()}
-            renderBody={(props) => (
-                <RenderBody
-                    {...props}
-                    highlightRegex={highlightRegex}
-                    htmlReactParserOptions={htmlReactParserOptions}
-                    linkifyOpts={linkifyOpts}
-                />
-            )}
-            renderImageContent={(props) => (
-                <ImageContent
-                    {...props}
-                    autoPlay={mediaAutoLoad}
-                    renderImage={(p) => <Image {...p} loading="lazy" />}
-                    renderViewer={(p) => <ImageViewer {...p} />}
-                />
-            )}
-            outlined={outlineAttachment}
+          content={getContent()}
+          renderBody={(props) => (
+            <RenderBody
+                {...props}
+                highlightRegex={highlightRegex}
+                htmlReactParserOptions={htmlReactParserOptions}
+                linkifyOpts={linkifyOpts}
+            />
+          )}
+          renderImageContent={(props) => (
+              <ImageContent
+                  {...props}
+                  autoPlay={mediaAutoLoad}
+                  renderImage={(p) => <Image {...p} loading="lazy" />}
+                  renderViewer={(p) => <ImageViewer {...p} />}
+              />
+          )}
+          outlined={outlineAttachment}
         />
         {
           renderCaption && (
-                <MNotice
-                    edited={edited}
-                    content={getContent()}
-                    renderBody={(props) => (
-                        <RenderBody
-                            {...props}
-                            highlightRegex={highlightRegex}
-                            htmlReactParserOptions={htmlReactParserOptions}
-                            linkifyOpts={linkifyOpts}
-                        />
-                    )}
-                    renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
+            <MNotice
+              edited={edited}
+              content={getContent()}
+              renderBody={(props) => (
+                <RenderBody
+                  {...props}
+                  highlightRegex={highlightRegex}
+                  htmlReactParserOptions={htmlReactParserOptions}
+                  linkifyOpts={linkifyOpts}
                 />
-            )
+              )}
+              renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
+            />
+          )
         }
       </>
     );
@@ -205,19 +205,20 @@ export function RenderMessageContent({
 
   if (msgType === MsgType.Video) {
     return (
-      <MVideo
-        content={getContent()}
-        renderAsFile={renderFile}
-        renderVideoContent={({ body, info, mimeType, url, encInfo }) => (
-          <VideoContent
-            body={body}
-            info={info}
-            mimeType={mimeType}
-            url={url}
-            encInfo={encInfo}
-            renderThumbnail={
-              mediaAutoLoad
-                ? () => (
+      <>
+        <MVideo
+          content={getContent()}
+          renderAsFile={renderFile}
+          renderVideoContent={({ body, info, mimeType, url, encInfo }) => (
+            <VideoContent
+              body={body}
+              info={info}
+              mimeType={mimeType}
+              url={url}
+              encInfo={encInfo}
+              renderThumbnail={
+                mediaAutoLoad
+                  ? () => (
                     <ThumbnailContent
                       info={info}
                       renderImage={(src) => (
@@ -225,26 +226,65 @@ export function RenderMessageContent({
                       )}
                     />
                   )
-                : undefined
-            }
-            renderVideo={(p) => <Video {...p} />}
-          />
-        )}
-        outlined={outlineAttachment}
-      />
+                  : undefined
+              }
+              renderVideo={(p) => <Video {...p} />}
+            />
+          )}
+          outlined={outlineAttachment}
+        />
+        {
+          renderCaption && (
+            <MNotice
+              edited={edited}
+              content={getContent()}
+              renderBody={(props) => (
+                <RenderBody
+                  {...props}
+                  highlightRegex={highlightRegex}
+                  htmlReactParserOptions={htmlReactParserOptions}
+                  linkifyOpts={linkifyOpts}
+                />
+              )}
+              renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
+            />
+          )
+        }
+      </>
+
     );
   }
 
   if (msgType === MsgType.Audio) {
     return (
-      <MAudio
-        content={getContent()}
-        renderAsFile={renderFile}
-        renderAudioContent={(props) => (
-          <AudioContent {...props} renderMediaControl={(p) => <MediaControl {...p} />} />
-        )}
-        outlined={outlineAttachment}
-      />
+      <>
+        <MAudio
+          content={getContent()}
+          renderAsFile={renderFile}
+          renderAudioContent={(props) => (
+            <AudioContent {...props} renderMediaControl={(p) => <MediaControl {...p} />} />
+          )}
+          outlined={outlineAttachment}
+        />
+        {
+          renderCaption && (
+            <MNotice
+              edited={edited}
+              content={getContent()}
+              renderBody={(props) => (
+                <RenderBody
+                  {...props}
+                  highlightRegex={highlightRegex}
+                  htmlReactParserOptions={htmlReactParserOptions}
+                  linkifyOpts={linkifyOpts}
+                />
+              )}
+              renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
+            />
+          )
+        }
+      </>
+
     );
   }
 

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -68,38 +68,62 @@ export function RenderMessageContent({
       </UrlPreviewHolder>
     );
   };
+  const content: IImageContent = getContent();
+  const renderCaption = content.filename && content.filename !== content.body;
+  let renderedCaption: React.ReactNode = null;
+  if(renderCaption) {
+    renderedCaption = (
+      <MNotice
+        edited={edited}
+        content={getContent()}
+        renderBody={(props) => (
+          <RenderBody
+            {...props}
+            highlightRegex={highlightRegex}
+            htmlReactParserOptions={htmlReactParserOptions}
+            linkifyOpts={linkifyOpts}
+          />
+        )}
+        renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
+      />
+    )
+  }
 
   const renderFile = () => (
-    <MFile
-      content={getContent()}
-      renderFileContent={({ body, mimeType, info, encInfo, url }) => (
-        <FileContent
-          body={body}
-          mimeType={mimeType}
-          renderAsPdfFile={() => (
-            <ReadPdfFile
+    <>
+      <MFile
+        content={getContent()}
+        renderFileContent={({ body, mimeType, info, encInfo, url }) => (
+            <FileContent
               body={body}
               mimeType={mimeType}
-              url={url}
-              encInfo={encInfo}
-              renderViewer={(p) => <PdfViewer {...p} />}
-            />
-          )}
-          renderAsTextFile={() => (
-            <ReadTextFile
-              body={body}
-              mimeType={mimeType}
-              url={url}
-              encInfo={encInfo}
-              renderViewer={(p) => <TextViewer {...p} />}
-            />
-          )}
-        >
-          <DownloadFile body={body} mimeType={mimeType} url={url} encInfo={encInfo} info={info} />
-        </FileContent>
-      )}
-      outlined={outlineAttachment}
-    />
+              renderAsPdfFile={() => (
+                <ReadPdfFile
+                  body={body}
+                  mimeType={mimeType}
+                  url={url}
+                  encInfo={encInfo}
+                  renderViewer={(p) => <PdfViewer {...p} />}
+                />
+              )}
+              renderAsTextFile={() => (
+                <ReadTextFile
+                  body={body}
+                  mimeType={mimeType}
+                  url={url}
+                  encInfo={encInfo}
+                  renderViewer={(p) => <TextViewer {...p} />}
+                />
+              )}
+            >
+              <DownloadFile body={body} mimeType={mimeType} url={url} encInfo={encInfo} info={info} />
+            </FileContent>
+
+        )}
+        outlined={outlineAttachment}
+      />
+      {renderedCaption}
+    </>
   );
 
   if (msgType === MsgType.Text) {
@@ -156,8 +180,6 @@ export function RenderMessageContent({
       />
     );
   }
-  const content: IImageContent = getContent();
-  const renderCaption = content.filename && content.filename !== content.body;
 
   if (msgType === MsgType.Image) {
     return (
@@ -174,23 +196,7 @@ export function RenderMessageContent({
           )}
           outlined={outlineAttachment}
         />
-        {
-          renderCaption && (
-            <MNotice
-              edited={edited}
-              content={getContent()}
-              renderBody={(props) => (
-                <RenderBody
-                  {...props}
-                  highlightRegex={highlightRegex}
-                  htmlReactParserOptions={htmlReactParserOptions}
-                  linkifyOpts={linkifyOpts}
-                />
-              )}
-              renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
-            />
-          )
-        }
+        {renderedCaption}
       </>
     );
   }
@@ -225,23 +231,7 @@ export function RenderMessageContent({
           )}
           outlined={outlineAttachment}
         />
-        {
-          renderCaption && (
-            <MNotice
-              edited={edited}
-              content={getContent()}
-              renderBody={(props) => (
-                <RenderBody
-                  {...props}
-                  highlightRegex={highlightRegex}
-                  htmlReactParserOptions={htmlReactParserOptions}
-                  linkifyOpts={linkifyOpts}
-                />
-              )}
-              renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
-            />
-          )
-        }
+        {renderedCaption}
       </>
 
     );
@@ -258,23 +248,7 @@ export function RenderMessageContent({
           )}
           outlined={outlineAttachment}
         />
-        {
-          renderCaption && (
-            <MNotice
-              edited={edited}
-              content={getContent()}
-              renderBody={(props) => (
-                <RenderBody
-                  {...props}
-                  highlightRegex={highlightRegex}
-                  htmlReactParserOptions={htmlReactParserOptions}
-                  linkifyOpts={linkifyOpts}
-                />
-              )}
-              renderUrlsPreview={urlPreview ? renderUrlsPreview : undefined}
-            />
-          )
-        }
+        {renderedCaption}
       </>
 
     );

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -172,6 +172,7 @@ export function MNotice({ edited, content, renderBody, renderUrlsPreview }: MNot
 
 type RenderImageContentProps = {
   body: string;
+  filename?: string;
   info?: IImageInfo & IThumbnailContent;
   mimeType?: string;
   url: string;
@@ -179,10 +180,11 @@ type RenderImageContentProps = {
 };
 type MImageProps = {
   content: IImageContent;
+  renderBody: (props: RenderBodyProps) => ReactNode;
   renderImageContent: (props: RenderImageContentProps) => ReactNode;
   outlined?: boolean;
 };
-export function MImage({ content, renderImageContent, outlined }: MImageProps) {
+export function MImage({ content, renderBody, renderImageContent, outlined }: MImageProps) {
   const imgInfo = content?.info;
   const mxcUrl = content.file?.url ?? content.url;
   if (typeof mxcUrl !== 'string') {

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -323,14 +323,14 @@ export function MFile({ content, renderFileContent, outlined }: MFileProps) {
     <Attachment outlined={outlined}>
       <AttachmentHeader>
         <FileHeader
-          body={content.body ?? 'Unnamed File'}
+          body={content.filename ?? content.body ?? 'Unnamed File'}
           mimeType={fileInfo?.mimetype ?? FALLBACK_MIMETYPE}
         />
       </AttachmentHeader>
       <AttachmentBox>
         <AttachmentContent>
           {renderFileContent({
-            body: content.body ?? 'File',
+            body: content.filename ?? content.body ?? 'File',
             info: fileInfo ?? {},
             mimeType: fileInfo?.mimetype ?? FALLBACK_MIMETYPE,
             url: mxcUrl,

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -284,7 +284,7 @@ export function MAudio({ content, renderAsFile, renderAudioContent, outlined }: 
   return (
     <Attachment outlined={outlined}>
       <AttachmentHeader>
-        <FileHeader body={content.body ?? 'Audio'} mimeType={safeMimeType} />
+        <FileHeader body={content.filename ?? content.body ?? 'Audio'} mimeType={safeMimeType} />
       </AttachmentHeader>
       <AttachmentBox>
         <AttachmentContent>

--- a/src/app/components/message/MsgTypeRenderers.tsx
+++ b/src/app/components/message/MsgTypeRenderers.tsx
@@ -180,11 +180,10 @@ type RenderImageContentProps = {
 };
 type MImageProps = {
   content: IImageContent;
-  renderBody: (props: RenderBodyProps) => ReactNode;
   renderImageContent: (props: RenderImageContentProps) => ReactNode;
   outlined?: boolean;
 };
-export function MImage({ content, renderBody, renderImageContent, outlined }: MImageProps) {
+export function MImage({ content, renderImageContent, outlined }: MImageProps) {
   const imgInfo = content?.info;
   const mxcUrl = content.file?.url ?? content.url;
   if (typeof mxcUrl !== 'string') {

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -227,18 +227,18 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       const contentsPromises = uploads.map(async (upload) => {
         const fileItem = selectedFiles.find((f) => f.file === upload.file);
         if (!fileItem) throw new Error('Broken upload');
-        const caption = toPlainText(editor.children).trim() || null;
+        const caption = toPlainText(editor.children).trim() || undefined;
 
         if (fileItem.file.type.startsWith('image')) {
           return getImageMsgContent(mx, fileItem, upload.mxc, caption);
         }
         if (fileItem.file.type.startsWith('video')) {
-          return getVideoMsgContent(mx, fileItem, upload.mxc);
+          return getVideoMsgContent(mx, fileItem, upload.mxc, caption);
         }
         if (fileItem.file.type.startsWith('audio')) {
-          return getAudioMsgContent(fileItem, upload.mxc);
+          return getAudioMsgContent(fileItem, upload.mxc, caption);
         }
-        return getFileMsgContent(fileItem, upload.mxc);
+        return getFileMsgContent(fileItem, upload.mxc, caption);
       });
       handleCancelUpload(uploads);
       const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -227,18 +227,25 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       const contentsPromises = uploads.map(async (upload) => {
         const fileItem = selectedFiles.find((f) => f.file === upload.file);
         if (!fileItem) throw new Error('Broken upload');
-        const caption = toPlainText(editor.children).trim() || undefined;
+        const plainTextCaption = toPlainText(editor.children).trim() || undefined;
+        const customHtmlCaption = trimCustomHtml(
+          toMatrixCustomHTML(editor.children, {
+            allowTextFormatting: true,
+            allowBlockMarkdown: isMarkdown,
+            allowInlineMarkdown: isMarkdown,
+          })
+        ) || undefined;
 
         if (fileItem.file.type.startsWith('image')) {
-          return getImageMsgContent(mx, fileItem, upload.mxc, caption);
+          return getImageMsgContent(mx, fileItem, upload.mxc, plainTextCaption, customHtmlCaption);
         }
         if (fileItem.file.type.startsWith('video')) {
-          return getVideoMsgContent(mx, fileItem, upload.mxc, caption);
+          return getVideoMsgContent(mx, fileItem, upload.mxc, plainTextCaption, customHtmlCaption);
         }
         if (fileItem.file.type.startsWith('audio')) {
-          return getAudioMsgContent(fileItem, upload.mxc, caption);
+          return getAudioMsgContent(fileItem, upload.mxc, plainTextCaption, customHtmlCaption);
         }
-        return getFileMsgContent(fileItem, upload.mxc, caption);
+        return getFileMsgContent(fileItem, upload.mxc, plainTextCaption, customHtmlCaption);
       });
       handleCancelUpload(uploads);
       const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -227,9 +227,10 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       const contentsPromises = uploads.map(async (upload) => {
         const fileItem = selectedFiles.find((f) => f.file === upload.file);
         if (!fileItem) throw new Error('Broken upload');
+        const caption = toPlainText(editor.children).trim() || null;
 
         if (fileItem.file.type.startsWith('image')) {
-          return getImageMsgContent(mx, fileItem, upload.mxc);
+          return getImageMsgContent(mx, fileItem, upload.mxc, caption);
         }
         if (fileItem.file.type.startsWith('video')) {
           return getVideoMsgContent(mx, fileItem, upload.mxc);
@@ -318,7 +319,9 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           content['m.relates_to'].is_falling_back = false;
         }
       }
-      mx.sendMessage(roomId, content);
+      if (!uploadBoardHandlers.current) {
+          mx.sendMessage(roomId, content);
+      }
       resetEditor(editor);
       resetEditorHistory(editor);
       setReplyDraft(undefined);

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -227,25 +227,17 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       const contentsPromises = uploads.map(async (upload) => {
         const fileItem = selectedFiles.find((f) => f.file === upload.file);
         if (!fileItem) throw new Error('Broken upload');
-        const plainTextCaption = toPlainText(editor.children).trim() || undefined;
-        const customHtmlCaption = trimCustomHtml(
-          toMatrixCustomHTML(editor.children, {
-            allowTextFormatting: true,
-            allowBlockMarkdown: isMarkdown,
-            allowInlineMarkdown: isMarkdown,
-          })
-        ) || undefined;
 
         if (fileItem.file.type.startsWith('image')) {
-          return getImageMsgContent(mx, fileItem, upload.mxc, plainTextCaption, customHtmlCaption);
+          return getImageMsgContent(mx, fileItem, upload.mxc);
         }
         if (fileItem.file.type.startsWith('video')) {
-          return getVideoMsgContent(mx, fileItem, upload.mxc, plainTextCaption, customHtmlCaption);
+          return getVideoMsgContent(mx, fileItem, upload.mxc);
         }
         if (fileItem.file.type.startsWith('audio')) {
-          return getAudioMsgContent(fileItem, upload.mxc, plainTextCaption, customHtmlCaption);
+          return getAudioMsgContent(fileItem, upload.mxc);
         }
-        return getFileMsgContent(fileItem, upload.mxc, plainTextCaption, customHtmlCaption);
+        return getFileMsgContent(fileItem, upload.mxc);
       });
       handleCancelUpload(uploads);
       const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));
@@ -326,9 +318,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           content['m.relates_to'].is_falling_back = false;
         }
       }
-      if (!uploadBoardHandlers.current) {
-          mx.sendMessage(roomId, content);
-      }
+      mx.sendMessage(roomId, content);
       resetEditor(editor);
       resetEditorHistory(editor);
       setReplyDraft(undefined);

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -76,7 +76,8 @@ export const getImageMsgContent = async (
 export const getVideoMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
-  mxc: string
+  mxc: string,
+  caption?: string
 ): Promise<IContent> => {
   const { file, originalFile, encInfo } = item;
 
@@ -85,7 +86,8 @@ export const getVideoMsgContent = async (
 
   const content: IContent = {
     msgtype: MsgType.Video,
-    body: file.name,
+    filename: file.name,
+    body: caption || file.name,
   };
   if (videoEl) {
     const [thumbError, thumbContent] = await to(
@@ -120,11 +122,12 @@ export const getVideoMsgContent = async (
   return content;
 };
 
-export const getAudioMsgContent = (item: TUploadItem, mxc: string): IContent => {
+export const getAudioMsgContent = (item: TUploadItem, mxc: string, caption?: string): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.Audio,
-    body: file.name,
+    filename: file.name,
+    body: caption || file.name,
     info: {
       mimetype: file.type,
       size: file.size,

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -43,8 +43,6 @@ export const getImageMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
   mxc: string,
-  plainTextCaption?: string,
-  customHtmlCaption?: string
 ): Promise<IContent> => {
   const { file, originalFile, encInfo } = item;
   const [imgError, imgEl] = await to(loadImageElement(getImageFileUrl(originalFile)));
@@ -53,12 +51,8 @@ export const getImageMsgContent = async (
   const content: IContent = {
     msgtype: MsgType.Image,
     filename: file.name,
-    body: plainTextCaption || file.name,
+    body: file.name,
   };
-  if(customHtmlCaption) {
-    content.formatted_body = customHtmlCaption;
-    content.format = "org.matrix.custom.html";
-  }
   if (imgEl) {
     const blurHash = encodeBlurHash(imgEl, 512, scaleYDimension(imgEl.width, 512, imgEl.height));
 
@@ -82,8 +76,6 @@ export const getVideoMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
   mxc: string,
-  plainTextCaption?: string,
-  customHtmlCaption?: string
 ): Promise<IContent> => {
   const { file, originalFile, encInfo } = item;
 
@@ -93,12 +85,8 @@ export const getVideoMsgContent = async (
   const content: IContent = {
     msgtype: MsgType.Video,
     filename: file.name,
-    body: plainTextCaption || file.name,
+    body: file.name,
   };
-  if(customHtmlCaption) {
-    content.formatted_body = customHtmlCaption;
-    content.format = "org.matrix.custom.html";
-  }
   if (videoEl) {
     const [thumbError, thumbContent] = await to(
       generateThumbnailContent(
@@ -132,21 +120,17 @@ export const getVideoMsgContent = async (
   return content;
 };
 
-export const getAudioMsgContent = (item: TUploadItem, mxc: string, plainTextCaption?: string, customHtmlCaption?: string): IContent => {
+export const getAudioMsgContent = (item: TUploadItem, mxc: string): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.Audio,
     filename: file.name,
-    body: plainTextCaption || file.name,
+    body: file.name,
     info: {
       mimetype: file.type,
       size: file.size,
     },
   };
-  if(customHtmlCaption) {
-    content.formatted_body = customHtmlCaption;
-    content.format = "org.matrix.custom.html";
-  }
   if (encInfo) {
     content.file = {
       ...encInfo,
@@ -158,21 +142,17 @@ export const getAudioMsgContent = (item: TUploadItem, mxc: string, plainTextCapt
   return content;
 };
 
-export const getFileMsgContent = (item: TUploadItem, mxc: string, plainTextCaption?: string, customHtmlCaption?: string): IContent => {
+export const getFileMsgContent = (item: TUploadItem, mxc: string): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.File,
-    body: plainTextCaption ?? file.name,
+    body: file.name,
     filename: file.name,
     info: {
       mimetype: file.type,
       size: file.size,
     },
   };
-  if(customHtmlCaption) {
-    content.formatted_body = customHtmlCaption;
-    content.format = "org.matrix.custom.html";
-  }
   if (encInfo) {
     content.file = {
       ...encInfo,

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -144,11 +144,11 @@ export const getAudioMsgContent = (item: TUploadItem, mxc: string, caption?: str
   return content;
 };
 
-export const getFileMsgContent = (item: TUploadItem, mxc: string): IContent => {
+export const getFileMsgContent = (item: TUploadItem, mxc: string, caption?: string): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.File,
-    body: file.name,
+    body: caption ?? file.name,
     filename: file.name,
     info: {
       mimetype: file.type,

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -43,7 +43,8 @@ export const getImageMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
   mxc: string,
-  caption?: string
+  plainTextCaption?: string,
+  customHtmlCaption?: string
 ): Promise<IContent> => {
   const { file, originalFile, encInfo } = item;
   const [imgError, imgEl] = await to(loadImageElement(getImageFileUrl(originalFile)));
@@ -52,8 +53,12 @@ export const getImageMsgContent = async (
   const content: IContent = {
     msgtype: MsgType.Image,
     filename: file.name,
-    body: caption || file.name,
+    body: plainTextCaption || file.name,
   };
+  if(customHtmlCaption) {
+    content.formatted_body = customHtmlCaption;
+    content.format = "org.matrix.custom.html";
+  }
   if (imgEl) {
     const blurHash = encodeBlurHash(imgEl, 512, scaleYDimension(imgEl.width, 512, imgEl.height));
 
@@ -77,7 +82,8 @@ export const getVideoMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
   mxc: string,
-  caption?: string
+  plainTextCaption?: string,
+  customHtmlCaption?: string
 ): Promise<IContent> => {
   const { file, originalFile, encInfo } = item;
 
@@ -87,8 +93,12 @@ export const getVideoMsgContent = async (
   const content: IContent = {
     msgtype: MsgType.Video,
     filename: file.name,
-    body: caption || file.name,
+    body: plainTextCaption || file.name,
   };
+  if(customHtmlCaption) {
+    content.formatted_body = customHtmlCaption;
+    content.format = "org.matrix.custom.html";
+  }
   if (videoEl) {
     const [thumbError, thumbContent] = await to(
       generateThumbnailContent(
@@ -122,17 +132,21 @@ export const getVideoMsgContent = async (
   return content;
 };
 
-export const getAudioMsgContent = (item: TUploadItem, mxc: string, caption?: string): IContent => {
+export const getAudioMsgContent = (item: TUploadItem, mxc: string, plainTextCaption?: string, customHtmlCaption?: string): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.Audio,
     filename: file.name,
-    body: caption || file.name,
+    body: plainTextCaption || file.name,
     info: {
       mimetype: file.type,
       size: file.size,
     },
   };
+  if(customHtmlCaption) {
+    content.formatted_body = customHtmlCaption;
+    content.format = "org.matrix.custom.html";
+  }
   if (encInfo) {
     content.file = {
       ...encInfo,
@@ -144,17 +158,21 @@ export const getAudioMsgContent = (item: TUploadItem, mxc: string, caption?: str
   return content;
 };
 
-export const getFileMsgContent = (item: TUploadItem, mxc: string, caption?: string): IContent => {
+export const getFileMsgContent = (item: TUploadItem, mxc: string, plainTextCaption?: string, customHtmlCaption?: string): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.File,
-    body: caption ?? file.name,
+    body: plainTextCaption ?? file.name,
     filename: file.name,
     info: {
       mimetype: file.type,
       size: file.size,
     },
   };
+  if(customHtmlCaption) {
+    content.formatted_body = customHtmlCaption;
+    content.format = "org.matrix.custom.html";
+  }
   if (encInfo) {
     content.file = {
       ...encInfo,

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -42,7 +42,8 @@ const generateThumbnailContent = async (
 export const getImageMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
-  mxc: string
+  mxc: string,
+  caption?: string
 ): Promise<IContent> => {
   const { file, originalFile, encInfo } = item;
   const [imgError, imgEl] = await to(loadImageElement(getImageFileUrl(originalFile)));
@@ -50,7 +51,8 @@ export const getImageMsgContent = async (
 
   const content: IContent = {
     msgtype: MsgType.Image,
-    body: file.name,
+    filename: file.name,
+    body: caption || file.name,
   };
   if (imgEl) {
     const blurHash = encodeBlurHash(imgEl, 512, scaleYDimension(imgEl.width, 512, imgEl.height));

--- a/src/types/matrix/common.ts
+++ b/src/types/matrix/common.ts
@@ -70,6 +70,7 @@ export type IAudioContent = {
 export type IFileContent = {
   msgtype: MsgType.File;
   body?: string;
+  filename?: string;
   url?: string;
   info?: IFileInfo & IThumbnailContent;
   file?: IEncryptedFile;

--- a/src/types/matrix/common.ts
+++ b/src/types/matrix/common.ts
@@ -52,6 +52,7 @@ export type IImageContent = {
 export type IVideoContent = {
   msgtype: MsgType.Video;
   body?: string;
+  filename?: string;
   url?: string;
   info?: IVideoInfo & IThumbnailContent;
   file?: IEncryptedFile;
@@ -60,6 +61,7 @@ export type IVideoContent = {
 export type IAudioContent = {
   msgtype: MsgType.Audio;
   body?: string;
+  filename?: string;
   url?: string;
   info?: IAudioInfo;
   file?: IEncryptedFile;

--- a/src/types/matrix/common.ts
+++ b/src/types/matrix/common.ts
@@ -43,6 +43,7 @@ export type IThumbnailContent = {
 export type IImageContent = {
   msgtype: MsgType.Image;
   body?: string;
+  filename?: string;
   url?: string;
   info?: IImageInfo & IThumbnailContent;
   file?: IEncryptedFile;


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
This PR will introduce rendering [file captions](https://spec.matrix.org/v1.12/client-server-api/#mimage:~:text=The%20original%20filename%20of%20the%20uploaded%20file.).
These were introduced in spec v1.10, and have recently seen wide adoption amongst Element and other clients. It is time that cinny had this too.

*Sending* captions is [out of scope for this PR](https://github.com/cinnyapp/cinny/pull/2059#discussion_r1883258813) and will be introduced later.

Fixes partially #1646

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code [*Image showing two uploads - one with no caption, and one with a caption*](https://files.nexy7574.co.uk/u/XQQKOF.jpg)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
