### PR TITLE
Load the local hostname's config, where possible

### DIFF
--- a/src/app/components/ClientConfigLoader.tsx
+++ b/src/app/components/ClientConfigLoader.tsx
@@ -4,8 +4,12 @@ import { ClientConfig } from '../hooks/useClientConfig';
 import { trimTrailingSlash } from '../utils/common';
 
 const getClientConfig = async (): Promise<ClientConfig> => {
-  const url = `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.json`;
-  const config = await fetch(url, { method: 'GET' });
+  let url = `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.${window.location.hostname}.json`;
+  let config = await fetch(url, { method: 'GET' });
+  if(config.status===404) {
+    url = `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.json`;
+    config = await fetch(url, { method: 'GET' });
+  }
   return config.json();
 };
 

--- a/src/app/components/ClientConfigLoader.tsx
+++ b/src/app/components/ClientConfigLoader.tsx
@@ -6,11 +6,24 @@ import { trimTrailingSlash } from '../utils/common';
 const getClientConfig = async (): Promise<ClientConfig> => {
   let url = `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.${window.location.hostname}.json`;
   let config = await fetch(url, { method: 'GET' });
-  if(config.status===404 || import.meta.env.MODE==="development") {
+
+  let loadedConfig = null;
+  try {
+    if(config.ok && import.meta.env.MODE != "development") {
+      loadedConfig = await config.json();
+    }
+  } catch (e) {}
+
+  if(!loadedConfig) {
     url = `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.json`;
     config = await fetch(url, { method: 'GET' });
+    try {
+      loadedConfig = await config.json();
+    } catch (e) {
+      return {};
+    }
   }
-  return config.json();
+  return loadedConfig;
 };
 
 type ClientConfigLoaderProps = {

--- a/src/app/components/ClientConfigLoader.tsx
+++ b/src/app/components/ClientConfigLoader.tsx
@@ -4,26 +4,21 @@ import { ClientConfig } from '../hooks/useClientConfig';
 import { trimTrailingSlash } from '../utils/common';
 
 const getClientConfig = async (): Promise<ClientConfig> => {
-  let url = `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.${window.location.hostname}.json`;
-  let config = await fetch(url, { method: 'GET' });
+  const defaultConfig = fetch(
+    `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.json`, { method: 'GET' }
+  );
+  const perSiteConfig = fetch(
+    `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.${window.location.hostname}.json`, { method: "GET" }
+  );
 
-  let loadedConfig = null;
-  try {
-    if(config.ok && import.meta.env.MODE != "development") {
-      loadedConfig = await config.json();
+  return perSiteConfig.then(
+    async (pscResponse) => {
+      if (import.meta.env.MODE === "development" || !pscResponse.ok) {
+        return defaultConfig.then((dcResponse) => dcResponse.json());
+      }
+      return pscResponse.json();
     }
-  } catch (e) {}
-
-  if(!loadedConfig) {
-    url = `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.json`;
-    config = await fetch(url, { method: 'GET' });
-    try {
-      loadedConfig = await config.json();
-    } catch (e) {
-      return {};
-    }
-  }
-  return loadedConfig;
+  )
 };
 
 type ClientConfigLoaderProps = {

--- a/src/app/components/ClientConfigLoader.tsx
+++ b/src/app/components/ClientConfigLoader.tsx
@@ -6,7 +6,7 @@ import { trimTrailingSlash } from '../utils/common';
 const getClientConfig = async (): Promise<ClientConfig> => {
   let url = `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.${window.location.hostname}.json`;
   let config = await fetch(url, { method: 'GET' });
-  if(config.status===404) {
+  if(config.status===404 || import.meta.env.MODE==="development") {
     url = `${trimTrailingSlash(import.meta.env.BASE_URL)}/config.json`;
     config = await fetch(url, { method: 'GET' });
   }


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
This change mirrors some nice but niche behaviour from Element, wherein `config.$HOSTNAME.json` is tried before `config.json`.
This is very handy, at least for me, because I serve cinny from a multitude of domains, but all from the same dist directory. This means if you visit cinny from one of my domains that is for a different homeserver, you will get the config for only one of my homeservers.
An example of this is https://cinny.transgender.ing - the `config.json` is loaded, which is intended for https://cinny.nexy7574.co.uk. Element, however, nicely tries to load `config.element.transgender.ing.json` in the first case, meaning I can serve a different default login server.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
