### PR TITLE
Fix state of the icons in Toolbar being too hard to see

### DIFF
--- a/src/app/components/editor/Editor.css.ts
+++ b/src/app/components/editor/Editor.css.ts
@@ -70,3 +70,11 @@ export const EditorToolbar = style({
 export const MarkdownBtnBox = style({
   paddingRight: config.space.S100,
 });
+
+export const invertOnPress = style({
+  selectors: {
+    '&[aria-pressed="true"]': {
+      filter: 'invert(1)',
+    },
+  },
+});

--- a/src/app/components/editor/Toolbar.tsx
+++ b/src/app/components/editor/Toolbar.tsx
@@ -72,6 +72,7 @@ export function MarkButton({ format, icon, tooltip }: MarkButtonProps) {
     <TooltipProvider tooltip={tooltip} delay={500}>
       {(triggerRef) => (
         <IconButton
+          className={css.invertOnPress}
           ref={triggerRef}
           variant="SurfaceVariant"
           onClick={handleClick}
@@ -104,6 +105,7 @@ export function BlockButton({ format, icon, tooltip }: BlockButtonProps) {
     <TooltipProvider tooltip={tooltip} delay={500}>
       {(triggerRef) => (
         <IconButton
+          className={css.invertOnPress}
           ref={triggerRef}
           variant="SurfaceVariant"
           onClick={handleClick}
@@ -342,6 +344,7 @@ export function Toolbar() {
             >
               {(triggerRef) => (
                 <IconButton
+                  className={css.invertOnPress}
                   ref={triggerRef}
                   variant="SurfaceVariant"
                   onClick={() => setIsMarkdown(!isMarkdown)}


### PR DESCRIPTION
### Description
This makes Cinny use filled variants of icons present in the Toolbar. I believe this is important because as of right now they are only highlighted slightly by the background, which does not differ much ([see this color comparison](https://webaim.org/resources/contrastchecker/?fcolor=404040&bcolor=333333)) from the background of Toolbar itself and thus makes this an accessibility issue for users with low sight like me.
See the relevant PR for the folds repo:
https://github.com/cinnyapp/folds/pull/60
See how this would look like in Cinny with the filled icons:
https://files.catbox.moe/jf3xep.mp4

Fixes icons in Toolbar not having enough visual hints to highlight their state.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [?] I have made corresponding changes to the documentation // Am I supposed to do that for this type of change?
- [x] My changes generate no new warnings
