### PR TITLE
Fix state of the icons in Toolbar being too hard to see

### DIFF
--- a/src/app/components/editor/Toolbar.tsx
+++ b/src/app/components/editor/Toolbar.tsx
@@ -58,6 +58,7 @@ type MarkButtonProps = { format: MarkType; icon: IconSrc; tooltip: ReactNode };
 export function MarkButton({ format, icon, tooltip }: MarkButtonProps) {
   const editor = useSlate();
   const disableInline = isBlockActive(editor, BlockType.CodeBlock);
+  const isActive = isMarkActive(editor, format);
 
   if (disableInline) {
     removeAllMark(editor);
@@ -75,12 +76,12 @@ export function MarkButton({ format, icon, tooltip }: MarkButtonProps) {
           ref={triggerRef}
           variant="SurfaceVariant"
           onClick={handleClick}
-          aria-pressed={isMarkActive(editor, format)}
+          aria-pressed={isActive}
           size="400"
           radii="300"
           disabled={disableInline}
         >
-          <Icon size="200" src={icon} />
+          <Icon size="200" src={icon} filled={isActive} />
         </IconButton>
       )}
     </TooltipProvider>
@@ -94,6 +95,7 @@ type BlockButtonProps = {
 };
 export function BlockButton({ format, icon, tooltip }: BlockButtonProps) {
   const editor = useSlate();
+  const isActive = isBlockActive(editor, format);
 
   const handleClick = () => {
     toggleBlock(editor, format, { level: 1 });
@@ -107,11 +109,11 @@ export function BlockButton({ format, icon, tooltip }: BlockButtonProps) {
           ref={triggerRef}
           variant="SurfaceVariant"
           onClick={handleClick}
-          aria-pressed={isBlockActive(editor, format)}
+          aria-pressed={isActive}
           size="400"
           radii="300"
         >
-          <Icon size="200" src={icon} />
+          <Icon size="200" src={icon} filled={isActive} />
         </IconButton>
       )}
     </TooltipProvider>
@@ -215,7 +217,11 @@ export function HeadingBlockButton() {
         size="400"
         radii="300"
       >
-        <Icon size="200" src={level ? Icons[`Heading${level}`] : Icons.Heading1} />
+        <Icon
+          size="200"
+          src={level ? Icons[`Heading${level}`] : Icons.Heading1}
+          filled={isActive}
+        />
         <Icon size="200" src={isActive ? Icons.Cross : Icons.ChevronBottom} />
       </IconButton>
     </PopOut>


### PR DESCRIPTION
### Description
This makes Cinny use filled variants of icons present in the Toolbar. I believe this is important because as of right now they are only highlighted slightly by the background, which does not differ much ([see this color comparison](https://webaim.org/resources/contrastchecker/?fcolor=404040&bcolor=333333) or [this one](https://webaim.org/resources/contrastchecker/?fcolor=4D4D4D&bcolor=333333), which is better but still not as good as filled icons) from the background of Toolbar itself and thus makes this an accessibility issue for users with low sight like me.

Obviously, this doesn't change anything without the relevant PR for the folds repo:
https://github.com/cinnyapp/folds/pull/60

To see how it looks like yourself you will have to build Cinny with a local version of the patched folds package. See how this should look like in Cinny with the filled icons:
https://files.catbox.moe/jf3xep.mp4

Fixes icons in Toolbar not having enough visual hints to highlight their state.



#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

**Note: I have already made a PR with such a description and name but accidentally did so with the wrong code. Long story short, I've been experimenting on how to improve this and during this time Cinny got updated. I pulled the changes, which made git suggest doing some git merge with the changes. I am not sure how, but it completely reverted the actual patch that I am pushing here and brought back one of the experimental solutions. I am super sorry for this, that was a giant blunder on my side.**