### PR TITLE
(DRAFT) Fix global notification rules by using /pushrules instead of /m.push_rules

### DIFF
--- a/src/app/molecules/global-notification/GlobalNotification.jsx
+++ b/src/app/molecules/global-notification/GlobalNotification.jsx
@@ -53,7 +53,7 @@ export function getTypeActions(type, highlightValue = false) {
 
 function useGlobalNotif() {
   const mx = useMatrixClient();
-  const pushRules = useAccountData('m.push_rules')?.getContent();
+  const pushRules = useAccountData('pushrules')?.getContent();
   const underride = pushRules?.global?.underride ?? [];
   const rulesToType = {
     [DM]: notifType.ON,
@@ -93,7 +93,7 @@ function useGlobalNotif() {
     }
     ruleContent.actions = getTypeActions(type);
 
-    mx.setAccountData('m.push_rules', content);
+    mx.setAccountData('pushrules', content);
   };
 
   const dmRule = underride.find((rule) => rule.rule_id === DM);

--- a/src/app/molecules/global-notification/KeywordNotification.jsx
+++ b/src/app/molecules/global-notification/KeywordNotification.jsx
@@ -29,7 +29,7 @@ const KEYWORD = 'keyword';
 
 function useKeywordNotif() {
   const mx = useMatrixClient();
-  const pushRules = useAccountData('m.push_rules')?.getContent();
+  const pushRules = useAccountData('pushrules')?.getContent();
   const override = pushRules?.global?.override ?? [];
   const content = pushRules?.global?.content ?? [];
 
@@ -92,7 +92,7 @@ function useKeywordNotif() {
       });
     }
 
-    mx.setAccountData('m.push_rules', evtContent);
+    mx.setAccountData('pushrules', evtContent);
   };
 
   const addKeyword = (keyword) => {
@@ -104,11 +104,11 @@ function useKeywordNotif() {
       default: false,
       actions: getTypeActions(rulesToType[KEYWORD] ?? notifType.NOISY, true),
     });
-    mx.setAccountData('m.push_rules', pushRules);
+    mx.setAccountData('pushrules', pushRules);
   };
   const removeKeyword = (rule) => {
     pushRules.global.content = content.filter((r) => r.rule_id !== rule.rule_id);
-    mx.setAccountData('m.push_rules', pushRules);
+    mx.setAccountData('pushrules', pushRules);
   };
 
   const dsRule = override.find((rule) => rule.rule_id === DISPLAY_NAME);

--- a/src/app/state/room-list/mutedRoomList.ts
+++ b/src/app/state/room-list/mutedRoomList.ts
@@ -49,7 +49,7 @@ export const useBindMutedRoomsAtom = (mx: MatrixClient, mutedAtom: typeof mutedR
   const setMuted = useSetAtom(mutedAtom);
 
   useEffect(() => {
-    const overrideRules = mx.getAccountData('m.push_rules')?.getContent<IPushRules>()
+    const overrideRules = mx.getAccountData('pushrules')?.getContent<IPushRules>()
       ?.global?.override;
     if (overrideRules) {
       const mutedRooms = overrideRules.reduce<string[]>((rooms, rule) => {

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -168,7 +168,7 @@ export const getNotificationType = (mx: MatrixClient, roomId: string): Notificat
   }
 
   if (!roomPushRule) {
-    const overrideRules = mx.getAccountData('m.push_rules')?.getContent<IPushRules>()
+    const overrideRules = mx.getAccountData('pushrules')?.getContent<IPushRules>()
       ?.global?.override;
     if (!overrideRules) return NotificationType.Default;
 


### PR DESCRIPTION
### Description
The ability to set account for event types changed. See https://spec.matrix.org/v1.12/client-server-api/#server-behaviour-12.

The correct api is documented here: https://spec.matrix.org/v1.12/client-server-api/#push-rules-api.

fixes https://github.com/cinnyapp/cinny/issues/2034

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
