### PR TITLE
Rendering formatted text as such in the original messages when replying

### DIFF
--- a/src/app/components/message/Reply.tsx
+++ b/src/app/components/message/Reply.tsx
@@ -109,7 +109,8 @@ export const Reply = as<'div', ReplyProps>(
         body={body}
         customBody={formattedBody}
         htmlReactParserOptions={htmlReactParserOptions}
-        linkifyOpts={LINKIFY_OPTS} />
+        linkifyOpts={LINKIFY_OPTS}
+      />
     ) : fallbackBody;
 
     return (

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -30,6 +30,7 @@ import {
   toRem,
 } from 'folds';
 
+import { HTMLReactParserOptions } from 'html-react-parser';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import {
   CustomEditor,
@@ -105,15 +106,15 @@ import {
   getAllParents,
   getMemberDisplayName,
   getMentionContent,
-  trimReplyFromBody,
 } from '../../utils/room';
 import { CommandAutocomplete } from './CommandAutocomplete';
 import { Command, SHRUG, TABLEFLIP, UNFLIP, useCommands } from '../../hooks/useCommands';
 import { mobileOrTablet } from '../../utils/user-agent';
 import { useElementSizeObserver } from '../../hooks/useElementSizeObserver';
-import { ReplyLayout, ThreadIndicator } from '../../components/message';
+import { RenderBody, ReplyLayout, ThreadIndicator } from '../../components/message';
 import { roomToParentsAtom } from '../../state/room/roomToParents';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
+import { getReactCustomHtmlParser, LINKIFY_OPTS } from '../../plugins/react-custom-html-parser';
 
 interface RoomInputProps {
   editor: Editor;
@@ -422,6 +423,26 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       });
     };
 
+    const linkifyOpts = LINKIFY_OPTS;
+
+    const htmlReactParserOptions = useMemo<HTMLReactParserOptions>(
+      () =>
+        getReactCustomHtmlParser(mx, room.roomId, {
+          linkifyOpts,
+          useAuthentication: false,
+        }),
+      [mx, room, linkifyOpts]
+    );
+
+    const replyDraftContent = replyDraft ? (
+        <RenderBody
+          body={replyDraft.body}
+          customBody={replyDraft.formattedBody}
+          htmlReactParserOptions={htmlReactParserOptions}
+          linkifyOpts={linkifyOpts}
+        />
+      ) : undefined;
+
     return (
       <div ref={ref}>
         {selectedFiles.length > 0 && (
@@ -550,7 +571,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
                       }
                     >
                       <Text size="T300" truncate>
-                        {trimReplyFromBody(replyDraft.body)}
+                        {replyDraftContent}
                       </Text>
                     </ReplyLayout>
                   </Box>

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -429,17 +429,26 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
       () =>
         getReactCustomHtmlParser(mx, room.roomId, {
           linkifyOpts,
-          useAuthentication: false,
+          useAuthentication: false
         }),
       [mx, room, linkifyOpts]
     );
 
+    // Preventing link from being clickable
+    let strFormattedBody;
+    const parser = new DOMParser();
+    if (replyDraft?.formattedBody) {
+      const domFormattedBody = parser.parseFromString(replyDraft.formattedBody, 'text/html');
+      const links = domFormattedBody.querySelectorAll('a');
+      links.forEach(link => link.removeAttribute('href'));
+      strFormattedBody = domFormattedBody.body.innerHTML;
+    }
+
     const replyDraftContent = replyDraft ? (
         <RenderBody
           body={replyDraft.body}
-          customBody={replyDraft.formattedBody}
+          customBody={strFormattedBody}
           htmlReactParserOptions={htmlReactParserOptions}
-          linkifyOpts={linkifyOpts}
         />
       ) : undefined;
 


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

As suggested in issue #189, formatting is rendered properly in the original message when replying to it:
![image](https://github.com/user-attachments/assets/b768950c-5f9f-4298-b37d-fcc2ab95d656)
![image](https://github.com/user-attachments/assets/296d3fa7-c392-49a1-985a-39183d800e46)

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
