### PR TITLE
Show image viewer when clicking url preview thumbnail

### DIFF
--- a/src/app/components/ImageOverlay.tsx
+++ b/src/app/components/ImageOverlay.tsx
@@ -10,7 +10,7 @@ export type RenderViewerProps = {
   requestClose: () => void;
 };
 
-export type ImageOverlayProps = RenderViewerProps & {
+type ImageOverlayProps = RenderViewerProps & {
   viewer: boolean;
   renderViewer: (props: RenderViewerProps) => ReactNode;
 };

--- a/src/app/components/ImageOverlay.tsx
+++ b/src/app/components/ImageOverlay.tsx
@@ -10,34 +10,36 @@ export type RenderViewerProps = {
   requestClose: () => void;
 };
 
-export const ImageOverlay = as<
-  'div',
-  {
-    src: string;
-    alt: string;
-    viewer: boolean;
-    requestClose: () => void;
-    renderViewer: (props: RenderViewerProps) => ReactNode;
-  }
->(({ src, alt, viewer, requestClose, renderViewer, ...props }, ref) => (
-  <Overlay {...props} ref={ref} open={viewer} backdrop={<OverlayBackdrop />}>
-    <OverlayCenter>
-      <FocusTrap
-        focusTrapOptions={{
-          initialFocus: false,
-          onDeactivate: () => requestClose(),
-          clickOutsideDeactivates: true,
-          escapeDeactivates: stopPropagation,
-        }}
-      >
-        <Modal className={ModalWide} size="500" onContextMenu={(evt: any) => evt.stopPropagation()}>
-          {renderViewer({
-            src,
-            alt,
-            requestClose: () => requestClose(),
-          })}
-        </Modal>
-      </FocusTrap>
-    </OverlayCenter>
-  </Overlay>
-));
+export type ImageOverlayProps = RenderViewerProps & {
+  viewer: boolean;
+  renderViewer: (props: RenderViewerProps) => ReactNode;
+};
+
+export const ImageOverlay = as<'div', ImageOverlayProps>(
+  ({ src, alt, viewer, requestClose, renderViewer, ...props }, ref) => (
+    <Overlay {...props} ref={ref} open={viewer} backdrop={<OverlayBackdrop />}>
+      <OverlayCenter>
+        <FocusTrap
+          focusTrapOptions={{
+            initialFocus: false,
+            onDeactivate: () => requestClose(),
+            clickOutsideDeactivates: true,
+            escapeDeactivates: stopPropagation,
+          }}
+        >
+          <Modal
+            className={ModalWide}
+            size="500"
+            onContextMenu={(evt: any) => evt.stopPropagation()}
+          >
+            {renderViewer({
+              src,
+              alt,
+              requestClose,
+            })}
+          </Modal>
+        </FocusTrap>
+      </OverlayCenter>
+    </Overlay>
+  )
+);

--- a/src/app/components/ImageOverlay.tsx
+++ b/src/app/components/ImageOverlay.tsx
@@ -1,0 +1,43 @@
+import FocusTrap from 'focus-trap-react';
+import { as, Modal, Overlay, OverlayBackdrop, OverlayCenter } from 'folds';
+import React, { ReactNode } from 'react';
+import { ModalWide } from '../styles/Modal.css';
+import { stopPropagation } from '../utils/keyboard';
+
+export type RenderViewerProps = {
+  src: string;
+  alt: string;
+  requestClose: () => void;
+};
+
+export const ImageOverlay = as<
+  'div',
+  {
+    src: string;
+    alt: string;
+    viewer: boolean;
+    requestClose: () => void;
+    renderViewer: (props: RenderViewerProps) => ReactNode;
+  }
+>(({ src, alt, viewer, requestClose, renderViewer, ...props }, ref) => (
+  <Overlay {...props} ref={ref} open={viewer} backdrop={<OverlayBackdrop />}>
+    <OverlayCenter>
+      <FocusTrap
+        focusTrapOptions={{
+          initialFocus: false,
+          onDeactivate: () => requestClose(),
+          clickOutsideDeactivates: true,
+          escapeDeactivates: stopPropagation,
+        }}
+      >
+        <Modal className={ModalWide} size="500" onContextMenu={(evt: any) => evt.stopPropagation()}>
+          {renderViewer({
+            src,
+            alt,
+            requestClose: () => requestClose(),
+          })}
+        </Modal>
+      </FocusTrap>
+    </OverlayCenter>
+  </Overlay>
+));

--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -64,7 +64,12 @@ export function RenderMessageContent({
     return (
       <UrlPreviewHolder>
         {filteredUrls.map((url) => (
-          <UrlPreviewCard key={url} url={url} ts={ts} />
+          <UrlPreviewCard
+            key={url}
+            url={url}
+            renderViewer={(p) => <ImageViewer {...p} />}
+            ts={ts}
+          />
         ))}
       </UrlPreviewHolder>
     );

--- a/src/app/components/url-preview/UrlPreviewCard.tsx
+++ b/src/app/components/url-preview/UrlPreviewCard.tsx
@@ -1,22 +1,7 @@
 import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { IPreviewUrlResponse } from 'matrix-js-sdk';
-import {
-  Box,
-  Icon,
-  IconButton,
-  Icons,
-  Modal,
-  Overlay,
-  OverlayCenter,
-  OverlayBackdrop,
-  Scroll,
-  Spinner,
-  Text,
-  as,
-  color,
-  config,
-} from 'folds';
-import FocusTrap from 'focus-trap-react';
+import { Box, Icon, IconButton, Icons, Scroll, Spinner, Text, as, color, config } from 'folds';
+import { RenderViewerProps, ImageOverlay } from '../ImageOverlay';
 import { AsyncStatus, useAsyncCallback } from '../../hooks/useAsyncCallback';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { UrlPreview, UrlPreviewContent, UrlPreviewDescription, UrlPreviewImg } from './UrlPreview';
@@ -28,16 +13,8 @@ import * as css from './UrlPreviewCard.css';
 import { tryDecodeURIComponent } from '../../utils/dom';
 import { mxcUrlToHttp } from '../../utils/matrix';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
-import { stopPropagation } from '../../utils/keyboard';
-import { ModalWide } from '../../styles/Modal.css';
 
 const linkStyles = { color: color.Success.Main };
-
-type RenderViewerProps = {
-  src: string;
-  alt: string;
-  requestClose: () => void;
-};
 
 export const UrlPreviewCard = as<
   'div',
@@ -80,30 +57,15 @@ export const UrlPreviewCard = as<
           />
         )}
         {imgUrl && (
-          <Overlay open={viewer} backdrop={<OverlayBackdrop />}>
-            <OverlayCenter>
-              <FocusTrap
-                focusTrapOptions={{
-                  initialFocus: false,
-                  onDeactivate: () => setViewer(false),
-                  clickOutsideDeactivates: true,
-                  escapeDeactivates: stopPropagation,
-                }}
-              >
-                <Modal
-                  className={ModalWide}
-                  size="500"
-                  onContextMenu={(evt: any) => evt.stopPropagation()}
-                >
-                  {renderViewer({
-                    src: imgUrl,
-                    alt: prev['og:title'],
-                    requestClose: () => setViewer(false),
-                  })}
-                </Modal>
-              </FocusTrap>
-            </OverlayCenter>
-          </Overlay>
+          <ImageOverlay
+            src={imgUrl}
+            alt={prev['og:title']}
+            viewer={viewer}
+            requestClose={() => {
+              setViewer(false);
+            }}
+            renderViewer={renderViewer}
+          />
         )}
         <UrlPreviewContent>
           <Text

--- a/src/app/components/url-preview/UrlPreviewCard.tsx
+++ b/src/app/components/url-preview/UrlPreviewCard.tsx
@@ -1,6 +1,22 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { IPreviewUrlResponse } from 'matrix-js-sdk';
-import { Box, Icon, IconButton, Icons, Scroll, Spinner, Text, as, color, config } from 'folds';
+import {
+  Box,
+  Icon,
+  IconButton,
+  Icons,
+  Modal,
+  Overlay,
+  OverlayCenter,
+  OverlayBackdrop,
+  Scroll,
+  Spinner,
+  Text,
+  as,
+  color,
+  config,
+} from 'folds';
+import FocusTrap from 'focus-trap-react';
 import { AsyncStatus, useAsyncCallback } from '../../hooks/useAsyncCallback';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { UrlPreview, UrlPreviewContent, UrlPreviewDescription, UrlPreviewImg } from './UrlPreview';
@@ -12,75 +28,120 @@ import * as css from './UrlPreviewCard.css';
 import { tryDecodeURIComponent } from '../../utils/dom';
 import { mxcUrlToHttp } from '../../utils/matrix';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
+import { stopPropagation } from '../../utils/keyboard';
+import { ModalWide } from '../../styles/Modal.css';
 
 const linkStyles = { color: color.Success.Main };
 
-export const UrlPreviewCard = as<'div', { url: string; ts: number }>(
-  ({ url, ts, ...props }, ref) => {
-    const mx = useMatrixClient();
-    const useAuthentication = useMediaAuthentication();
-    const [previewStatus, loadPreview] = useAsyncCallback(
-      useCallback(() => mx.getUrlPreview(url, ts), [url, ts, mx])
+type RenderViewerProps = {
+  src: string;
+  alt: string;
+  requestClose: () => void;
+};
+
+export const UrlPreviewCard = as<
+  'div',
+  { url: string; ts: number; renderViewer: (props: RenderViewerProps) => ReactNode }
+>(({ url, ts, renderViewer, ...props }, ref) => {
+  const mx = useMatrixClient();
+  const useAuthentication = useMediaAuthentication();
+  const [viewer, setViewer] = useState(false);
+  const [previewStatus, loadPreview] = useAsyncCallback(
+    useCallback(() => mx.getUrlPreview(url, ts), [url, ts, mx])
+  );
+
+  useEffect(() => {
+    loadPreview();
+  }, [loadPreview]);
+
+  if (previewStatus.status === AsyncStatus.Error) return null;
+
+  const renderContent = (prev: IPreviewUrlResponse) => {
+    const thumbUrl = mxcUrlToHttp(
+      mx,
+      prev['og:image'] || '',
+      useAuthentication,
+      256,
+      256,
+      'scale',
+      false
     );
 
-    useEffect(() => {
-      loadPreview();
-    }, [loadPreview]);
-
-    if (previewStatus.status === AsyncStatus.Error) return null;
-
-    const renderContent = (prev: IPreviewUrlResponse) => {
-      const imgUrl = mxcUrlToHttp(
-        mx,
-        prev['og:image'] || '',
-        useAuthentication,
-        256,
-        256,
-        'scale',
-        false
-      );
-
-      return (
-        <>
-          {imgUrl && <UrlPreviewImg src={imgUrl} alt={prev['og:title']} title={prev['og:title']} />}
-          <UrlPreviewContent>
-            <Text
-              style={linkStyles}
-              truncate
-              as="a"
-              href={url}
-              target="_blank"
-              rel="noreferrer"
-              size="T200"
-              priority="300"
-            >
-              {typeof prev['og:site_name'] === 'string' && `${prev['og:site_name']} | `}
-              {tryDecodeURIComponent(url)}
-            </Text>
-            <Text truncate priority="400">
-              <b>{prev['og:title']}</b>
-            </Text>
-            <Text size="T200" priority="300">
-              <UrlPreviewDescription>{prev['og:description']}</UrlPreviewDescription>
-            </Text>
-          </UrlPreviewContent>
-        </>
-      );
-    };
+    const imgUrl = mxcUrlToHttp(mx, prev['og:image'] || '', useAuthentication);
 
     return (
-      <UrlPreview {...props} ref={ref}>
-        {previewStatus.status === AsyncStatus.Success ? (
-          renderContent(previewStatus.data)
-        ) : (
-          <Box grow="Yes" alignItems="Center" justifyContent="Center">
-            <Spinner variant="Secondary" size="400" />
-          </Box>
+      <>
+        {thumbUrl && (
+          <UrlPreviewImg
+            src={thumbUrl}
+            alt={prev['og:title']}
+            title={prev['og:title']}
+            onClick={() => setViewer(true)}
+          />
         )}
-      </UrlPreview>
+        {imgUrl && (
+          <Overlay open={viewer} backdrop={<OverlayBackdrop />}>
+            <OverlayCenter>
+              <FocusTrap
+                focusTrapOptions={{
+                  initialFocus: false,
+                  onDeactivate: () => setViewer(false),
+                  clickOutsideDeactivates: true,
+                  escapeDeactivates: stopPropagation,
+                }}
+              >
+                <Modal
+                  className={ModalWide}
+                  size="500"
+                  onContextMenu={(evt: any) => evt.stopPropagation()}
+                >
+                  {renderViewer({
+                    src: imgUrl,
+                    alt: prev['og:title'],
+                    requestClose: () => setViewer(false),
+                  })}
+                </Modal>
+              </FocusTrap>
+            </OverlayCenter>
+          </Overlay>
+        )}
+        <UrlPreviewContent>
+          <Text
+            style={linkStyles}
+            truncate
+            as="a"
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            size="T200"
+            priority="300"
+          >
+            {typeof prev['og:site_name'] === 'string' && `${prev['og:site_name']} | `}
+            {tryDecodeURIComponent(url)}
+          </Text>
+          <Text truncate priority="400">
+            <b>{prev['og:title']}</b>
+          </Text>
+          <Text size="T200" priority="300">
+            <UrlPreviewDescription>{prev['og:description']}</UrlPreviewDescription>
+          </Text>
+        </UrlPreviewContent>
+      </>
     );
-  }
-);
+  };
+
+  return (
+    <UrlPreview {...props} ref={ref}>
+      {previewStatus.status === AsyncStatus.Success ? (
+        renderContent(previewStatus.data)
+      ) : (
+        <Box grow="Yes" alignItems="Center" justifyContent="Center">
+          <Spinner variant="Secondary" size="400" />
+        </Box>
+      )}
+    </UrlPreview>
+  );
+});
 
 export const UrlPreviewHolder = as<'div'>(({ children, ...props }, ref) => {
   const scrollRef = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
Show an image viewer when clicking the thumbnail in the url preview, similar to Element. Uses the same code as image content, maybe some deduplication necessary.

<img alt="showcase of image preview" src="https://github.com/user-attachments/assets/a9e64c33-965a-4d68-810e-d22d076869db" width=450>

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
