### PR TITLE
fix: Auto select in "Join with Address" text input

### DIFF
--- a/src/app/organisms/join-alias/JoinAlias.jsx
+++ b/src/app/organisms/join-alias/JoinAlias.jsx
@@ -75,7 +75,7 @@ function JoinAliasContent({ term, requestClose }) {
 
   return (
     <form className="join-alias" onSubmit={handleSubmit}>
-      <Input label="Address" value={term} name="alias" required />
+      <Input label="Address" value={term} name="alias" required autoFocus />
       {error && (
         <Text className="join-alias__error" variant="b3">
           {error}


### PR DESCRIPTION

### Description
This PR adds native autoFocus support to the input field in the "Join Alias" dialog. When the dialog is opened, the alias input now receives focus automatically, allowing users to start typing immediately without needing to click the input field manually.

### Before changes
https://github.com/user-attachments/assets/8c5fd85c-33a5-4905-8947-3666ee6762b4

### After changes
https://github.com/user-attachments/assets/d105f4a9-806c-411a-bf0a-2c05ba8e4cfb



Fixes #2261 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
