### PR TITLE
Update presence status when the window loses focus.

### DIFF
--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue } from 'jotai';
 import React, { ReactNode, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { RoomEvent, RoomEventHandlerMap } from 'matrix-js-sdk';
+import { RoomEvent, RoomEventHandlerMap, SetPresence } from 'matrix-js-sdk';
 import { roomToUnreadAtom, unreadEqual, unreadInfoToUnread } from '../../state/room/roomToUnread';
 import LogoSVG from '../../../../public/res/svg/cinny.svg';
 import LogoUnreadSVG from '../../../../public/res/svg/cinny-unread.svg';
@@ -253,6 +253,28 @@ function MessageNotifications() {
   );
 }
 
+function UpdatePresence() {
+  const mx = useMatrixClient();
+  const onFocus = () => {
+    mx.setSyncPresence(SetPresence.Online);
+  };
+  const onBlur = () => {
+    mx.setSyncPresence(SetPresence.Unavailable);
+  }
+
+  useEffect(() => {
+    window.addEventListener("focus", onFocus);
+    window.addEventListener("blur", onBlur);
+    onFocus();
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener("blur", onBlur);
+    };
+  }, [mx]);
+
+  return null;
+}
+
 type ClientNonUIFeaturesProps = {
   children: ReactNode;
 };
@@ -265,6 +287,7 @@ export function ClientNonUIFeatures({ children }: ClientNonUIFeaturesProps) {
       <FaviconUpdater />
       <InviteNotifications />
       <MessageNotifications />
+      <UpdatePresence />
       {children}
     </>
   );

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -255,14 +255,15 @@ function MessageNotifications() {
 
 function UpdatePresence() {
   const mx = useMatrixClient();
-  const onFocus = () => {
-    mx.setSyncPresence(SetPresence.Online);
-  };
-  const onBlur = () => {
-    mx.setSyncPresence(SetPresence.Unavailable);
-  }
 
   useEffect(() => {
+    const onFocus = () => {
+      mx.setSyncPresence(SetPresence.Online);
+    };
+    const onBlur = () => {
+      mx.setSyncPresence(SetPresence.Unavailable);
+    }
+
     window.addEventListener("focus", onFocus);
     window.addEventListener("blur", onBlur);
     onFocus();


### PR DESCRIPTION
(cherry picked from commit 9c99a84ad0513abf33c119ab68590997435f62c8)

<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Background: My friends complained that I always show online but don’t read messages in time and confused. I discovered that Cinny keeps setting my account’s presence status to `online` even when I put the client in the background.

Apparently, Cinny sent `/sync` requests to Homeserver even in the background, which is reasonable for a client to catch up with events. However, this misled the HS to believe that the user was `online`. 

Investigating Matrix Client-Server API specification, I discovered that an user's presence status is inferred by Homeserver based on API activities or be explicitly set by Client via [`/presence/{userId}/status`](https://spec.matrix.org/v1.15/client-server-api/#put_matrixclientv3presenceuseridstatus) or implicitly set along with [`/sync`](https://spec.matrix.org/v1.15/client-server-api/#get_matrixclientv3sync) requests using parameter `set_presence`. `matrix-js-sdk` provides both methods [`setPresence`](https://matrix-org.github.io/matrix-js-sdk/classes/matrix.MatrixClient.html#setpresence) and [`setSyncPresence`](https://matrix-org.github.io/matrix-js-sdk/classes/matrix.MatrixClient.html#setsyncpresence).

Ideally, we choose to use `setSyncPresence`. Because even if presence status were set via `/presence`, `/sync` API calls that keep running in the background still confuse Homeserver to consider the user being `online`. Furthermore, this way won't override possible presence status from other clients.

After this change, a) when the Cinny window is focused, the presence is `online`, b) when the Cinny window is *not* focused and running in background, the presence is `unavailable`, c) when the Cinny isn't running, the presence is `offline`. 

<!-- Fixes # -->

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
