### PR TITLE
Change: Prevent publishing rooms with incompatible joinrules to directory

### DIFF
--- a/src/app/features/common-settings/general/RoomPublish.tsx
+++ b/src/app/features/common-settings/general/RoomPublish.tsx
@@ -12,6 +12,7 @@ import { IPowerLevels, powerLevelAPI } from '../../../hooks/usePowerLevels';
 import { StateEvent } from '../../../../types/matrix/room';
 import { useMatrixClient } from '../../../hooks/useMatrixClient';
 import { useStateEvent } from '../../../hooks/useStateEvent';
+import { ExtendedJoinRules } from '../../../components/JoinRulesSwitcher';
 
 type RoomPublishProps = {
   powerLevels: IPowerLevels;
@@ -27,7 +28,7 @@ export function RoomPublish({ powerLevels }: RoomPublishProps) {
   );
   const joinRuleEvent = useStateEvent(room, StateEvent.RoomJoinRules);
   const content = joinRuleEvent?.getContent<RoomJoinRulesEventContent>();
-  const rule: JoinRule = content?.join_rule ?? JoinRule.Invite;
+  const rule: ExtendedJoinRules = (content?.join_rule as ExtendedJoinRules) ?? JoinRule.Invite;
 
   const { visibilityState, setVisibility } = useRoomDirectoryVisibility(room.roomId);
 
@@ -35,7 +36,8 @@ export function RoomPublish({ powerLevels }: RoomPublishProps) {
 
   const loading =
     visibilityState.status === AsyncStatus.Loading || toggleState.status === AsyncStatus.Loading;
-  const validRule = rule === JoinRule.Public || rule === JoinRule.Knock;
+  const validRule =
+    rule === JoinRule.Public || rule === JoinRule.Knock || rule === 'knock_restricted';
 
   return (
     <SequenceCard

--- a/src/app/features/common-settings/general/RoomPublish.tsx
+++ b/src/app/features/common-settings/general/RoomPublish.tsx
@@ -53,7 +53,7 @@ export function RoomPublish({ powerLevels }: RoomPublishProps) {
               <Switch
                 value={visibilityState.data}
                 onChange={toggleVisibility}
-                disabled={!(canEditCanonical && validRule)}
+                disabled={!canEditCanonical || !validRule}
               />
             )}
           </Box>

--- a/src/app/features/common-settings/general/RoomPublish.tsx
+++ b/src/app/features/common-settings/general/RoomPublish.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, color, Spinner, Switch, Text } from 'folds';
-import { MatrixError } from 'matrix-js-sdk';
+import { JoinRule, MatrixError } from 'matrix-js-sdk';
+import { RoomJoinRulesEventContent } from 'matrix-js-sdk/lib/types';
 import { SequenceCard } from '../../../components/sequence-card';
 import { SequenceCardStyle } from '../../room-settings/styles.css';
 import { SettingTile } from '../../../components/setting-tile';
@@ -10,6 +11,7 @@ import { AsyncStatus, useAsyncCallback } from '../../../hooks/useAsyncCallback';
 import { IPowerLevels, powerLevelAPI } from '../../../hooks/usePowerLevels';
 import { StateEvent } from '../../../../types/matrix/room';
 import { useMatrixClient } from '../../../hooks/useMatrixClient';
+import { useStateEvent } from '../../../hooks/useStateEvent';
 
 type RoomPublishProps = {
   powerLevels: IPowerLevels;
@@ -23,6 +25,9 @@ export function RoomPublish({ powerLevels }: RoomPublishProps) {
     StateEvent.RoomCanonicalAlias,
     userPowerLevel
   );
+  const joinRuleEvent = useStateEvent(room, StateEvent.RoomJoinRules);
+  const content = joinRuleEvent?.getContent<RoomJoinRulesEventContent>();
+  const rule: JoinRule = content?.join_rule ?? JoinRule.Invite;
 
   const { visibilityState, setVisibility } = useRoomDirectoryVisibility(room.roomId);
 
@@ -30,6 +35,7 @@ export function RoomPublish({ powerLevels }: RoomPublishProps) {
 
   const loading =
     visibilityState.status === AsyncStatus.Loading || toggleState.status === AsyncStatus.Loading;
+  const validRule = rule === JoinRule.Public || rule === JoinRule.Knock;
 
   return (
     <SequenceCard
@@ -47,7 +53,7 @@ export function RoomPublish({ powerLevels }: RoomPublishProps) {
               <Switch
                 value={visibilityState.data}
                 onChange={toggleVisibility}
-                disabled={!canEditCanonical}
+                disabled={!(canEditCanonical && validRule)}
               />
             )}
           </Box>


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Currently rooms that cannot be joined from the directory can be published to the directory. To fix this I suggest disabling the option to publish if the room has incompatible joinrules such as "Invite Only" or "Space Members Only"


Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [o] New feature (non-breaking change which adds functionality)
- [o] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [o] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [o] I have commented my code, particularly in hard-to-understand areas
- [o] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
