### PR TITLE
Load Thumbnail first and fall back to the original image if it cannot be loaded

### DIFF
--- a/src/app/components/RenderMessageContent.tsx
+++ b/src/app/components/RenderMessageContent.tsx
@@ -184,13 +184,32 @@ export function RenderMessageContent({
   }
 
   if (msgType === MsgType.Image) {
+    const content: IImageContent = getContent();
+    const width = content?.info?.w;
+    const height = content?.info?.h;
+    let thumbnail: {
+      imgWidth: number,
+      imgHeight: number,
+      resizeMethod: string
+    } | undefined;
+    if (width && height) {
+      const scale = (width > height ? width : height) / 800;
+      if (width > 800 || height > 800 && scale > 1) {
+        thumbnail = {
+          imgWidth: width / scale,
+          imgHeight: height / scale,
+          resizeMethod: "scale",
+        }
+      }
+    }
     return (
       <>
         <MImage
-          content={getContent()}
+          content={content}
           renderImageContent={(props) => (
             <ImageContent
               {...props}
+              {...thumbnail}
               autoPlay={mediaAutoLoad}
               renderImage={(p) => <Image {...p} loading="lazy" />}
               renderViewer={(p) => <ImageViewer {...p} />}

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -94,7 +94,7 @@ export const ImageContent = as<'div', ImageContentProps>(
 
     const [srcState, loadSrc] = useAsyncCallback(
       useCallback(async () => {
-        const mediaUrl = (useThumbnail ? mxcUrlToHttp(mx, url, useAuthentication) : mxcUrlToHttp(mx, url, useAuthentication, imgWidth, imgHeight, resizeMethod)) ?? url;
+        const mediaUrl = (useThumbnail ? mxcUrlToHttp(mx, url, useAuthentication, imgWidth, imgHeight, resizeMethod) : mxcUrlToHttp(mx, url, useAuthentication)) ?? url;
         if (encInfo) {
           const fileContent = await downloadEncryptedMedia(mediaUrl, (encBuf) =>
             decryptFile(encBuf, mimeType ?? FALLBACK_MIMETYPE, encInfo)

--- a/src/app/components/message/content/ImageContent.tsx
+++ b/src/app/components/message/content/ImageContent.tsx
@@ -96,9 +96,13 @@ export const ImageContent = as<'div', ImageContentProps>(
       useCallback(async () => {
         const mediaUrl = (useThumbnail ? mxcUrlToHttp(mx, url, useAuthentication, imgWidth, imgHeight, resizeMethod) : mxcUrlToHttp(mx, url, useAuthentication)) ?? url;
         if (encInfo) {
-          const fileContent = await downloadEncryptedMedia(mediaUrl, (encBuf) =>
-            decryptFile(encBuf, mimeType ?? FALLBACK_MIMETYPE, encInfo)
-          );
+          const decrypt = (encBuf: ArrayBuffer) => decryptFile(encBuf, mimeType ?? FALLBACK_MIMETYPE, encInfo);
+          let fileContent;
+          try {
+            fileContent = await downloadEncryptedMedia(mediaUrl, decrypt);
+          } catch {
+            fileContent = await downloadEncryptedMedia(mxcUrlToHttp(mx, url, useAuthentication) ?? url, decrypt);
+          }
           return URL.createObjectURL(fileContent);
         }
         return mediaUrl;

--- a/src/types/matrix/common.ts
+++ b/src/types/matrix/common.ts
@@ -49,6 +49,7 @@ export type IImageContent = {
   url?: string;
   info?: IImageInfo & IThumbnailContent;
   file?: IEncryptedFile;
+  info?: { h: number, w: number };
   [MATRIX_SPOILER_PROPERTY_NAME]?: boolean;
   [MATRIX_SPOILER_REASON_PROPERTY_NAME]?: string;
 };


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

When viewing messages, thumbnails are loaded first, if loading fails, the original image is loaded as a fallback.

<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- #2444 

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
