### PR TITLE
feat: allow using filenames in codeblocks

### DIFF
--- a/src/app/plugins/markdown/block/rules.ts
+++ b/src/app/plugins/markdown/block/rules.ts
@@ -16,8 +16,12 @@ export const CodeBlockRule: BlockMDRule = {
   match: (text) => text.match(CODEBLOCK_REG_1),
   html: (match) => {
     const [, g1, g2] = match;
-    const classNameAtt = g1 ? ` class="language-${g1}"` : '';
-    return `<pre data-md="${CODEBLOCK_MD_1}"><code${classNameAtt}>${g2}</code></pre>`;
+    // use last identifier after dot, e.g. for "example.json" gets us "json" as language code.
+    const langCode = g1 ? g1.substring(g1.lastIndexOf('.') + 1) : null;
+    const filename = g1 != langCode ? g1 : null;
+    const classNameAtt = langCode ? ` class="language-${langCode}"` : '';
+    const filenameAtt = filename ? ` data-label="${filename}"` : '';
+    return `<pre data-md="${CODEBLOCK_MD_1}"><code${classNameAtt}${filenameAtt}>${g2}</code></pre>`;
   },
 };
 

--- a/src/app/plugins/react-custom-html-parser.tsx
+++ b/src/app/plugins/react-custom-html-parser.tsx
@@ -232,8 +232,9 @@ export function CodeBlock({
   opts: HTMLReactParserOptions;
 }) {
   const code = children[0];
-  const languageClass =
-    code instanceof Element && code.name === 'code' ? code.attribs.class : undefined;
+  const attribs = code instanceof Element && code.name === 'code' ? code.attribs : undefined;
+  const languageClass = attribs?.class;
+  const customLabel = attribs?.['data-label'];
   const language =
     languageClass && languageClass.startsWith('language-')
       ? languageClass.replace('language-', '')
@@ -262,7 +263,7 @@ export function CodeBlock({
       <Header variant="Surface" size="400" className={css.CodeBlockHeader}>
         <Box grow="Yes">
           <Text size="L400" truncate>
-            {language ?? 'Code'}
+            {customLabel ?? language ?? 'Code'}
           </Text>
         </Box>
         <Box shrink="No" gap="200">

--- a/src/app/utils/sanitize.ts
+++ b/src/app/utils/sanitize.ts
@@ -71,7 +71,7 @@ const permittedTagToAttributes = {
   ul: ['data-md'],
   a: ['name', 'target', 'href', 'rel', 'data-md'],
   img: ['width', 'height', 'alt', 'title', 'src', 'data-mx-emoticon'],
-  code: ['class', 'data-md'],
+  code: ['class', 'data-md', 'data-label'],
   strong: ['data-md'],
   i: ['data-md'],
   em: ['data-md'],


### PR DESCRIPTION

### Description

Makes it possible to send code blocks as \`\`\`filename.json or \`\`\`src/app/example.js and having Cinny display the filename in the header of code blocks as well as only using the text after the dot as the language specifier.

- If there is a dot in the syntax name, we instead treat it as the filename and only everything after the last dot as the syntax name
- we use a custom "data-label" attribute on the code block to specify the name of the file (so only compatible with new Cinny versions, no support for other matrix clients and no spec/standard for this)

Preview in Cinny:

<img width="452" height="389" alt="image" src="https://github.com/user-attachments/assets/1c13d75a-1cd0-44b6-b0c1-f261b19841d0" />

&nbsp;

Preview in old Cinny and probably other clients:

<img width="400" height="383" alt="image" src="https://github.com/user-attachments/assets/d9be1c5c-e217-4df1-aa1d-a9db1a6fd900" />

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
