### PR TITLE
Fix: '- list' counted as ordered list

### DIFF
--- a/src/app/plugins/markdown/block/rules.ts
+++ b/src/app/plugins/markdown/block/rules.ts
@@ -11,13 +11,13 @@ export const HeadingRule: BlockMDRule = {
 };
 
 const CODEBLOCK_MD_1 = '```';
-const CODEBLOCK_REG_1 = /^`{3}(\S*)\n((?:.*\n)+?)`{3} *(?!.)\n?/m;
+const CODEBLOCK_REG_1 = /^(`{3,}|~{3,})(?:[ \t]*(\S+))?\n([\s\S]*?)\1 *(?!.)\n?/m;
 export const CodeBlockRule: BlockMDRule = {
   match: (text) => text.match(CODEBLOCK_REG_1),
   html: (match) => {
-    const [, g1, g2] = match;
-    const classNameAtt = g1 ? ` class="language-${g1}"` : '';
-    return `<pre data-md="${CODEBLOCK_MD_1}"><code${classNameAtt}>${g2}</code></pre>`;
+    const [ , fence, lang, code ] = match;
+    const classNameAtt = lang ? ` class="language-${lang}"` : '';
+    return `<pre data-md="${fence}"><code${classNameAtt}>${code}</code></pre>`;
   },
 };
 

--- a/src/app/plugins/markdown/block/rules.ts
+++ b/src/app/plugins/markdown/block/rules.ts
@@ -44,11 +44,11 @@ export const BlockQuoteRule: BlockMDRule = {
 };
 
 const ORDERED_LIST_MD_1 = '-';
-const O_LIST_ITEM_PREFIX = /^(-|[\da-zA-Z]\.) */;
+const O_LIST_ITEM_PREFIX = /^([\da-zA-Z]\.) */;
 const O_LIST_START = /^([\d])\./;
 const O_LIST_TYPE = /^([aAiI])\./;
 const O_LIST_TRAILING_NEWLINE = /\n$/;
-const ORDERED_LIST_REG_1 = /(^(?:-|[\da-zA-Z]\.) +.+\n?)+/m;
+const ORDERED_LIST_REG_1 = /(^(?:[\da-zA-Z]\.) +.+\n?)+/m;
 export const OrderedListRule: BlockMDRule = {
   match: (text) => text.match(ORDERED_LIST_REG_1),
   html: (match, parseInline) => {
@@ -74,9 +74,9 @@ export const OrderedListRule: BlockMDRule = {
 };
 
 const UNORDERED_LIST_MD_1 = '*';
-const U_LIST_ITEM_PREFIX = /^\* */;
+const U_LIST_ITEM_PREFIX = /^([-*+]) */;
 const U_LIST_TRAILING_NEWLINE = /\n$/;
-const UNORDERED_LIST_REG_1 = /(^\* +.+\n?)+/m;
+const UNORDERED_LIST_REG_1 = /(^([-*+]) +.+\n?)+/m;
 export const UnorderedListRule: BlockMDRule = {
   match: (text) => text.match(UNORDERED_LIST_REG_1),
   html: (match, parseInline) => {


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

markdown strings as below are rendered to ordered list instead of unordered list:

``` md
- Should be <ul>
- instead of <ol>
```

is rendered to

``` html
<ol data-md=\"-\"><li><p>Should be &lt;ul&gt;</p></li><li><p>instead of &lt;ol&gt;</p></li></ol>
```

Some simple rule configuration would fix this, but more detailed, like symbol character in `data-md="${..._LIST_MD_1}"` should be fixed too.

After this change, `- ` `* ` `+ ` should be rendered to unordered list and only `1.` & `a.` will be ordered list.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
