### PR TITLE
Change Room Card to support knocking

### DIFF
--- a/src/app/components/room-card/RoomCard.tsx
+++ b/src/app/components/room-card/RoomCard.tsx
@@ -357,7 +357,7 @@ export const RoomCard = as<'div', RoomCardProps>(
           </Button>
         )}
         {typeof joinedRoomId !== 'string' &&
-          joinState.status !== AsyncStatus.Error &&
+          knockState.status !== AsyncStatus.Error &&
           (action === 'knock' || action === 'knock_waiting') && (
             <Button
               onClick={knock}
@@ -408,7 +408,7 @@ export const RoomCard = as<'div', RoomCardProps>(
               message={knockState.error.message || 'Failed to send request to join. Unknown Error.'}
             />
           )}
-        {typeof joinedRoomId !== 'string' && action == 'invite_only' && (
+        {typeof joinedRoomId !== 'string' && action === 'invite_only' && (
           <Button disabled={true} variant="Secondary" size="300">
             <Text size="B300">Invite-only</Text>
           </Button>

--- a/src/app/components/room-card/RoomCard.tsx
+++ b/src/app/components/room-card/RoomCard.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback, useRef, useState } from 'react';
-import { MatrixError, Room } from 'matrix-js-sdk';
+import { MatrixError, Room, JoinRule } from 'matrix-js-sdk';
 import {
   Avatar,
   Badge,
@@ -27,7 +27,7 @@ import { millify } from '../../plugins/millify';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { AsyncStatus, useAsyncCallback } from '../../hooks/useAsyncCallback';
 import { onEnterOrSpace, stopPropagation } from '../../utils/keyboard';
-import { RoomType, StateEvent } from '../../../types/matrix/room';
+import { Membership, RoomType, StateEvent } from '../../../types/matrix/room';
 import { useJoinedRoomId } from '../../hooks/useJoinedRoomId';
 import { useElementSizeObserver } from '../../hooks/useElementSizeObserver';
 import { getRoomAvatarUrl, getStateEvent } from '../../utils/room';
@@ -131,6 +131,80 @@ function ErrorDialog({
   );
 }
 
+const getNextJoinAction = (
+  joinRule: string | undefined,
+  membership: string | undefined
+): 'join' | 'knock' | 'knock_waiting' | 'invite_only' => {
+  switch (joinRule) {
+    case JoinRule.Public:
+      return 'join';
+    case JoinRule.Invite:
+      if (membership === Membership.Invite) {
+        return 'join';
+      } else {
+        return 'invite_only';
+      }
+    case JoinRule.Private:
+      return 'join';
+    case JoinRule.Knock:
+      if (membership === Membership.Knock) {
+        return 'knock_waiting';
+      } else if (membership === Membership.Invite) {
+        return 'join';
+      } else {
+        return 'knock';
+      }
+    case JoinRule.Restricted:
+      return 'join';
+    case undefined:
+      return 'invite_only';
+    default:
+      return 'join';
+  }
+};
+
+const ActionError = ({
+  action,
+  title,
+  message,
+}: {
+  action: () => void;
+  title: string;
+  message: string;
+}) => {
+  return (
+    <Box gap="200">
+      <Button
+        onClick={action}
+        className={css.ActionButton}
+        variant="Critical"
+        fill="Solid"
+        size="300"
+      >
+        <Text size="B300" truncate>
+          Retry
+        </Text>
+      </Button>
+      <ErrorDialog title={title} message={message}>
+        {(openError) => (
+          <Button
+            onClick={openError}
+            className={css.ActionButton}
+            variant="Critical"
+            fill="Soft"
+            outlined
+            size="300"
+          >
+            <Text size="B300" truncate>
+              View Error
+            </Text>
+          </Button>
+        )}
+      </ErrorDialog>
+    </Box>
+  );
+};
+
 type RoomCardProps = {
   roomIdOrAlias: string;
   allRooms: string[];
@@ -139,6 +213,8 @@ type RoomCardProps = {
   topic?: string;
   memberCount?: number;
   roomType?: string;
+  joinRule?: string;
+  membership?: string;
   viaServers?: string[];
   onView?: (roomId: string) => void;
   renderTopicViewer: (name: string, topic: string, requestClose: () => void) => ReactNode;
@@ -154,6 +230,8 @@ export const RoomCard = as<'div', RoomCardProps>(
       topic,
       memberCount,
       roomType,
+      joinRule,
+      membership,
       viaServers,
       onView,
       renderTopicViewer,
@@ -197,11 +275,22 @@ export const RoomCard = as<'div', RoomCardProps>(
       )
     );
 
+    const action = getNextJoinAction(joinRule, membership);
+
     const [joinState, join] = useAsyncCallback<Room, MatrixError, []>(
       useCallback(() => mx.joinRoom(roomIdOrAlias, { viaServers }), [mx, roomIdOrAlias, viaServers])
     );
     const joining =
       joinState.status === AsyncStatus.Loading || joinState.status === AsyncStatus.Success;
+
+    const [knockState, knock] = useAsyncCallback<{ room_id: string }, MatrixError, []>(
+      useCallback(
+        () => mx.knockRoom(roomIdOrAlias, { viaServers }),
+        [mx, roomIdOrAlias, viaServers]
+      )
+    );
+    const knocking = knockState.status === AsyncStatus.Loading;
+    const alreadyKnocked = knockState.status === AsyncStatus.Success || action === 'knock_waiting';
 
     const [viewTopic, setViewTopic] = useState(false);
     const closeTopic = () => setViewTopic(false);
@@ -267,52 +356,62 @@ export const RoomCard = as<'div', RoomCardProps>(
             </Text>
           </Button>
         )}
-        {typeof joinedRoomId !== 'string' && joinState.status !== AsyncStatus.Error && (
-          <Button
-            onClick={join}
-            variant="Secondary"
-            size="300"
-            disabled={joining}
-            before={joining && <Spinner size="50" variant="Secondary" fill="Soft" />}
-          >
-            <Text size="B300" truncate>
-              {joining ? 'Joining' : 'Join'}
-            </Text>
-          </Button>
-        )}
-        {typeof joinedRoomId !== 'string' && joinState.status === AsyncStatus.Error && (
-          <Box gap="200">
+        {typeof joinedRoomId !== 'string' &&
+          joinState.status !== AsyncStatus.Error &&
+          (action === 'knock' || action === 'knock_waiting') && (
             <Button
-              onClick={join}
-              className={css.ActionButton}
-              variant="Critical"
-              fill="Solid"
+              onClick={knock}
+              variant="Secondary"
               size="300"
+              disabled={knocking || alreadyKnocked}
+              before={knocking && <Spinner size="50" variant="Secondary" fill="Soft" />}
             >
               <Text size="B300" truncate>
-                Retry
+                {alreadyKnocked
+                  ? 'Request Sent'
+                  : knocking
+                  ? 'Requesting Access'
+                  : 'Request Access'}
               </Text>
             </Button>
-            <ErrorDialog
-              title="Join Error"
-              message={joinState.error.message || 'Failed to join. Unknown Error.'}
+          )}
+        {typeof joinedRoomId !== 'string' &&
+          joinState.status !== AsyncStatus.Error &&
+          action === 'join' && (
+            <Button
+              onClick={join}
+              variant="Secondary"
+              size="300"
+              disabled={joining}
+              before={joining && <Spinner size="50" variant="Secondary" fill="Soft" />}
             >
-              {(openError) => (
-                <Button
-                  onClick={openError}
-                  className={css.ActionButton}
-                  variant="Critical"
-                  fill="Soft"
-                  outlined
-                  size="300"
-                >
-                  <Text size="B300" truncate>
-                    View Error
-                  </Text>
-                </Button>
-              )}
-            </ErrorDialog>
-          </Box>
+              <Text size="B300" truncate>
+                {joining ? 'Joining' : 'Join'}
+              </Text>
+            </Button>
+          )}
+        {typeof joinedRoomId !== 'string' &&
+          action === 'join' &&
+          joinState.status === AsyncStatus.Error && (
+            <ActionError
+              action={join}
+              title={'Join Error'}
+              message={joinState.error.message || 'Failed to join. Unknown Error.'}
+            />
+          )}
+        {typeof joinedRoomId !== 'string' &&
+          action === 'knock' &&
+          knockState.status === AsyncStatus.Error && (
+            <ActionError
+              action={knock}
+              title={'Join Request Error'}
+              message={knockState.error.message || 'Failed to send request to join. Unknown Error.'}
+            />
+          )}
+        {typeof joinedRoomId !== 'string' && action == 'invite_only' && (
+          <Button disabled={true} variant="Secondary" size="300">
+            <Text size="B300">Invite-only</Text>
+          </Button>
         )}
       </RoomCardBase>
     );

--- a/src/app/features/join-before-navigate/JoinBeforeNavigate.tsx
+++ b/src/app/features/join-before-navigate/JoinBeforeNavigate.tsx
@@ -66,6 +66,8 @@ export function JoinBeforeNavigate({
                   topic={summary?.topic}
                   memberCount={summary?.num_joined_members}
                   roomType={summary?.room_type}
+                  joinRule={summary?.join_rule}
+                  membership={summary?.membership}
                   viaServers={viaServers}
                   renderTopicViewer={(name, topic, requestClose) => (
                     <RoomTopicViewer name={name} topic={topic} requestClose={requestClose} />


### PR DESCRIPTION
### Description
Updates the Room Card to support [MSC 2403](https://github.com/matrix-org/matrix-spec-proposals/pull/2403). Cinny allows server admins to set rooms to knock only but doesn't allow users to actually make knocks. This PR is just a simple change to add knocking.

As a side effect we can also notify the user when a server is invite-only. This could be a separate PR if desired but I've wrapped it in here. The current behavior where you hit join and then get an error is confusing.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [✓] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [✓] My code follows the style guidelines of this project
- [✓] I have performed a self-review of my own code
- [✓] I have commented my code, particularly in hard-to-understand areas
- [✓] I have made corresponding changes to the documentation
- [✓] My changes generate no new warnings
