### PR TITLE
Keyboard‑first reply flow in the room timeline

### DIFF
--- a/src/app/features/room/RoomInput.css.ts
+++ b/src/app/features/room/RoomInput.css.ts
@@ -1,0 +1,16 @@
+import { style } from '@vanilla-extract/css';
+import { color, config } from 'folds';
+
+export const RoomInputFrame = style({
+  outline: 'none',
+});
+
+export const RoomInputFrameActive = style({
+  selectors: {
+    '&:focus-within': {
+      outline: `2px solid ${color.Primary.ContainerActive}`,
+      outlineOffset: config.space.S100,
+      borderRadius: config.radii.R400,
+    },
+  },
+});

--- a/src/app/features/room/RoomInput.css.ts
+++ b/src/app/features/room/RoomInput.css.ts
@@ -6,11 +6,7 @@ export const RoomInputFrame = style({
 });
 
 export const RoomInputFrameActive = style({
-  selectors: {
-    '&:focus-within': {
-      outline: `2px solid ${color.Primary.ContainerActive}`,
-      outlineOffset: config.space.S100,
-      borderRadius: config.radii.R400,
-    },
-  },
+  outline: `2px solid ${color.Primary.ContainerActive}`,
+  outlineOffset: config.space.S100,
+  borderRadius: config.radii.R400,
 });

--- a/src/app/features/room/RoomTimeline.css.ts
+++ b/src/app/features/room/RoomTimeline.css.ts
@@ -35,11 +35,14 @@ export const TimelineScrollFrame = style({
   display: 'flex',
   flexDirection: 'column',
   flexGrow: 1,
+  minWidth: 0,
   minHeight: 0,
 });
 
 export const TimelineScroll = style({
   outline: 'none',
   flexGrow: 1,
+  minWidth: 0,
   minHeight: 0,
+  maxWidth: '100%',
 });

--- a/src/app/features/room/RoomTimeline.css.ts
+++ b/src/app/features/room/RoomTimeline.css.ts
@@ -1,3 +1,4 @@
+import { style } from '@vanilla-extract/css';
 import { RecipeVariants, recipe } from '@vanilla-extract/recipes';
 import { DefaultReset, config } from 'folds';
 
@@ -28,3 +29,17 @@ export const TimelineFloat = recipe({
 });
 
 export type TimelineFloatVariants = RecipeVariants<typeof TimelineFloat>;
+
+export const TimelineScrollFrame = style({
+  outline: 'none',
+  display: 'flex',
+  flexDirection: 'column',
+  flexGrow: 1,
+  minHeight: 0,
+});
+
+export const TimelineScroll = style({
+  outline: 'none',
+  flexGrow: 1,
+  minHeight: 0,
+});

--- a/src/app/features/room/RoomView.tsx
+++ b/src/app/features/room/RoomView.tsx
@@ -59,6 +59,7 @@ const shouldFocusMessageField = (evt: KeyboardEvent): boolean => {
 export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
   const roomInputRef = useRef<HTMLDivElement>(null);
   const roomViewRef = useRef<HTMLDivElement>(null);
+  const timelineScrollRef = useRef<HTMLDivElement>(null);
   const [timelineNavMode, setTimelineNavMode] = useState(false);
 
   const [hideActivity] = useSetting(settingsAtom, 'hideActivity');
@@ -92,6 +93,14 @@ export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
     )
   );
 
+  const enterTimelineNav = useCallback(() => {
+    setTimelineNavMode(true);
+    timelineScrollRef.current?.focus();
+    requestAnimationFrame(() => {
+      timelineScrollRef.current?.focus();
+    });
+  }, []);
+
   useEffect(() => {
     setTimelineNavMode(false);
   }, [roomId, eventId]);
@@ -108,6 +117,7 @@ export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
           editor={editor}
           timelineNavMode={timelineNavMode}
           onExitTimelineNav={() => setTimelineNavMode(false)}
+          timelineScrollRef={timelineScrollRef}
         />
         <RoomViewTyping room={room} />
       </Box>
@@ -129,7 +139,7 @@ export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
                   fileDropContainerRef={roomViewRef}
                   ref={roomInputRef}
                   timelineNavMode={timelineNavMode}
-                  onEnterTimelineNav={() => setTimelineNavMode(true)}
+                  onEnterTimelineNav={enterTimelineNav}
                   onExitTimelineNav={() => setTimelineNavMode(false)}
                 />
               )}

--- a/src/app/features/room/RoomView.tsx
+++ b/src/app/features/room/RoomView.tsx
@@ -9,7 +9,7 @@ import { usePowerLevelsContext } from '../../hooks/usePowerLevels';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { useEditor } from '../../components/editor';
 import { RoomInputPlaceholder } from './RoomInputPlaceholder';
-import { RoomTimeline } from './RoomTimeline';
+import { RoomTimeline, RoomTimelineHandle } from './RoomTimeline';
 import { RoomViewTyping } from './RoomViewTyping';
 import { RoomTombstone } from './RoomTombstone';
 import { RoomInput } from './RoomInput';
@@ -59,6 +59,7 @@ const shouldFocusMessageField = (evt: KeyboardEvent): boolean => {
 export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
   const roomInputRef = useRef<HTMLDivElement>(null);
   const roomViewRef = useRef<HTMLDivElement>(null);
+  const roomTimelineRef = useRef<RoomTimelineHandle>(null);
 
   const [hideActivity] = useSetting(settingsAtom, 'hideActivity');
 
@@ -101,6 +102,7 @@ export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
           eventId={eventId}
           roomInputRef={roomInputRef}
           editor={editor}
+          ref={roomTimelineRef}
         />
         <RoomViewTyping room={room} />
       </Box>
@@ -121,6 +123,9 @@ export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
                   roomId={roomId}
                   fileDropContainerRef={roomViewRef}
                   ref={roomInputRef}
+                  onRequestTimelineSelect={(direction) =>
+                    roomTimelineRef.current?.selectEdge(direction)
+                  }
                 />
               )}
               {!canMessage && (

--- a/src/app/features/room/RoomView.tsx
+++ b/src/app/features/room/RoomView.tsx
@@ -95,6 +95,7 @@ export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
 
   const enterTimelineNav = useCallback(() => {
     setTimelineNavMode(true);
+    // Ensure timeline receives the next keypress for navigation.
     timelineScrollRef.current?.focus();
     requestAnimationFrame(() => {
       timelineScrollRef.current?.focus();

--- a/src/app/features/room/RoomView.tsx
+++ b/src/app/features/room/RoomView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Text, config } from 'folds';
 import { EventType, Room } from 'matrix-js-sdk';
 import { ReactEditor } from 'slate-react';
@@ -9,7 +9,7 @@ import { usePowerLevelsContext } from '../../hooks/usePowerLevels';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { useEditor } from '../../components/editor';
 import { RoomInputPlaceholder } from './RoomInputPlaceholder';
-import { RoomTimeline, RoomTimelineHandle } from './RoomTimeline';
+import { RoomTimeline } from './RoomTimeline';
 import { RoomViewTyping } from './RoomViewTyping';
 import { RoomTombstone } from './RoomTombstone';
 import { RoomInput } from './RoomInput';
@@ -59,7 +59,7 @@ const shouldFocusMessageField = (evt: KeyboardEvent): boolean => {
 export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
   const roomInputRef = useRef<HTMLDivElement>(null);
   const roomViewRef = useRef<HTMLDivElement>(null);
-  const roomTimelineRef = useRef<RoomTimelineHandle>(null);
+  const [timelineNavMode, setTimelineNavMode] = useState(false);
 
   const [hideActivity] = useSetting(settingsAtom, 'hideActivity');
 
@@ -92,6 +92,10 @@ export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
     )
   );
 
+  useEffect(() => {
+    setTimelineNavMode(false);
+  }, [roomId, eventId]);
+
   return (
     <Page ref={roomViewRef}>
       <RoomViewHeader />
@@ -102,7 +106,8 @@ export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
           eventId={eventId}
           roomInputRef={roomInputRef}
           editor={editor}
-          ref={roomTimelineRef}
+          timelineNavMode={timelineNavMode}
+          onExitTimelineNav={() => setTimelineNavMode(false)}
         />
         <RoomViewTyping room={room} />
       </Box>
@@ -123,9 +128,9 @@ export function RoomView({ room, eventId }: { room: Room; eventId?: string }) {
                   roomId={roomId}
                   fileDropContainerRef={roomViewRef}
                   ref={roomInputRef}
-                  onRequestTimelineSelect={(direction) =>
-                    roomTimelineRef.current?.selectEdge(direction)
-                  }
+                  timelineNavMode={timelineNavMode}
+                  onEnterTimelineNav={() => setTimelineNavMode(true)}
+                  onExitTimelineNav={() => setTimelineNavMode(false)}
                 />
               )}
               {!canMessage && (

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -818,13 +818,13 @@ export const Message = as<'div', MessageProps>(
     );
 
     const msgContentJSX = (
-      <Box direction="Column" alignSelf="Start" style={{ maxWidth: '100%' }}>
+      <Box direction="Column" alignSelf="Start" style={{ maxWidth: '100%', width: '100%' }}>
         {reply}
         {edit && onEditId ? (
           <MessageEditor
             style={{
               maxWidth: '100%',
-              width: '100vw',
+              width: '100%',
             }}
             roomId={room.roomId}
             room={room}

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -659,6 +659,7 @@ export type MessageProps = {
   mEvent: MatrixEvent;
   collapse: boolean;
   highlight: boolean;
+  selected?: boolean;
   edit?: boolean;
   canDelete?: boolean;
   canSendReaction?: boolean;
@@ -693,6 +694,7 @@ export const Message = as<'div', MessageProps>(
       mEvent,
       collapse,
       highlight,
+      selected,
       edit,
       canDelete,
       canSendReaction,
@@ -885,7 +887,7 @@ export const Message = as<'div', MessageProps>(
         space={messageSpacing}
         collapse={collapse}
         highlight={highlight}
-        selected={!!menuAnchor || !!emojiBoardAnchor}
+        selected={!!selected || !!menuAnchor || !!emojiBoardAnchor}
         {...props}
         {...hoverProps}
         {...focusWithinProps}
@@ -1156,6 +1158,7 @@ export type EventProps = {
   room: Room;
   mEvent: MatrixEvent;
   highlight: boolean;
+  selected?: boolean;
   canDelete?: boolean;
   messageSpacing: MessageSpacing;
   hideReadReceipts?: boolean;
@@ -1168,6 +1171,7 @@ export const Event = as<'div', EventProps>(
       room,
       mEvent,
       highlight,
+      selected,
       canDelete,
       messageSpacing,
       hideReadReceipts,
@@ -1213,7 +1217,7 @@ export const Event = as<'div', EventProps>(
         space={messageSpacing}
         autoCollapse
         highlight={highlight}
-        selected={!!menuAnchor}
+        selected={!!selected || !!menuAnchor}
         {...props}
         {...hoverProps}
         {...focusWithinProps}

--- a/src/app/features/room/roomTimelineUtils.ts
+++ b/src/app/features/room/roomTimelineUtils.ts
@@ -1,0 +1,21 @@
+import { EventTimeline, MatrixEvent } from 'matrix-js-sdk';
+
+export const getTimelineAndBaseIndex = (
+  timelines: EventTimeline[],
+  index: number
+): [EventTimeline | undefined, number] => {
+  let uptoTimelineLen = 0;
+  const timeline = timelines.find((t) => {
+    uptoTimelineLen += t.getEvents().length;
+    if (index < uptoTimelineLen) return true;
+    return false;
+  });
+  if (!timeline) return [undefined, 0];
+  return [timeline, uptoTimelineLen - timeline.getEvents().length];
+};
+
+export const getTimelineRelativeIndex = (absoluteIndex: number, timelineBaseIndex: number) =>
+  absoluteIndex - timelineBaseIndex;
+
+export const getTimelineEvent = (timeline: EventTimeline, index: number): MatrixEvent | undefined =>
+  timeline.getEvents()[index];

--- a/src/app/features/room/useRoomTimelineNav.ts
+++ b/src/app/features/room/useRoomTimelineNav.ts
@@ -24,6 +24,14 @@ export type TimelineSelectionAction = {
   handler: (eventId?: string) => void;
 };
 
+/**
+ * Keyboard navigation/selection helper for room timelines.
+ *
+ * Notes:
+ * - `getItems` must return absolute item indices that align with `linkedTimelines`.
+ * - `shouldRenderEvent` should match the render logic, or selection may land on hidden events.
+ * - `scrollToItem` is expected to support `align: 'center'` and `behavior: 'instant'`.
+ */
 type TimelineSelectionContext = {
   timelineNavMode: boolean;
   getItems: () => ItemIndex[];
@@ -35,6 +43,10 @@ type TimelineSelectionContext = {
   ) => void;
   onExitTimelineNav: () => void;
   isEditableActive?: () => boolean;
+  /**
+   * Increment when timeline contents change without a new linkedTimelines reference
+   * (e.g. redactions/edits that cause in-place updates).
+   */
   timelineRevision?: number;
 };
 

--- a/src/app/features/room/useRoomTimelineNav.ts
+++ b/src/app/features/room/useRoomTimelineNav.ts
@@ -50,6 +50,7 @@ const buildSelectableItems = (
   const selectable: TimelineSelectableItem[] = [];
   let baseIndex = 0;
 
+  // Walk linked timelines and map each event to its absolute index.
   linkedTimelines.forEach((timeline) => {
     const events = timeline.getEvents();
     for (let index = 0; index < events.length; index += 1) {
@@ -99,6 +100,7 @@ export const useRoomTimelineNav = (
   const [selectedEventId, setSelectedEventId] = useState<string | undefined>();
 
   const getSelectableItems = useCallback(() => {
+    // Build from live timeline data so selection doesn't depend on the virtualized range.
     if (timelineRevision === -1) return [];
     return buildSelectableItems(linkedTimelines, shouldRenderEvent);
   }, [linkedTimelines, shouldRenderEvent, timelineRevision]);

--- a/src/app/features/room/useRoomTimelineNav.ts
+++ b/src/app/features/room/useRoomTimelineNav.ts
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { isKeyHotkey } from 'is-hotkey';
+import { EventTimeline, MatrixEvent } from 'matrix-js-sdk';
+
+import {
+  getTimelineAndBaseIndex,
+  getTimelineRelativeIndex,
+  getTimelineEvent,
+} from './roomTimelineUtils';
+
+type ItemIndex = number;
+
+export type TimelineSelectableItem = {
+  eventId: string;
+  itemIndex: ItemIndex;
+};
+
+export type TimelineSelectionAction = {
+  hotkey: string;
+  requiresSelection?: boolean;
+  clearsSelection?: boolean;
+  exitsNav?: boolean;
+  handler: (eventId?: string) => void;
+};
+
+type TimelineSelectionContext = {
+  timelineNavMode: boolean;
+  getItems: () => ItemIndex[];
+  linkedTimelines: EventTimeline[];
+  shouldRenderEvent: (mEvent: MatrixEvent) => boolean;
+  scrollToItem: (
+    itemIndex: ItemIndex,
+    opts: { behavior: ScrollBehavior; align: string; stopInView: boolean }
+  ) => void;
+  onExitTimelineNav: () => void;
+  isEditableActive?: () => boolean;
+};
+
+const getSelectableItems = (
+  getItems: TimelineSelectionContext['getItems'],
+  linkedTimelines: TimelineSelectionContext['linkedTimelines'],
+  shouldRenderEvent: TimelineSelectionContext['shouldRenderEvent']
+): TimelineSelectableItem[] => {
+  const items = getItems();
+  const selectable: TimelineSelectableItem[] = [];
+
+  items.forEach((itemIndex) => {
+    const [eventTimeline, baseIndex] = getTimelineAndBaseIndex(linkedTimelines, itemIndex);
+    if (!eventTimeline) return;
+    const mEvent = getTimelineEvent(
+      eventTimeline,
+      getTimelineRelativeIndex(itemIndex, baseIndex)
+    );
+    const mEventId = mEvent?.getId();
+    if (!mEvent || !mEventId) return;
+    if (!shouldRenderEvent(mEvent)) return;
+    selectable.push({ eventId: mEventId, itemIndex });
+  });
+
+  return selectable;
+};
+
+export const useRoomTimelineNav = (
+  context: TimelineSelectionContext,
+  actions: TimelineSelectionAction[]
+) => {
+  const {
+    timelineNavMode,
+    getItems,
+    linkedTimelines,
+    shouldRenderEvent,
+    scrollToItem,
+    onExitTimelineNav,
+    isEditableActive,
+  } = context;
+  const [selectedEventId, setSelectedEventId] = useState<string | undefined>();
+
+  const selectableItems = useMemo(
+    () => getSelectableItems(getItems, linkedTimelines, shouldRenderEvent),
+    [getItems, linkedTimelines, shouldRenderEvent]
+  );
+
+  useEffect(() => {
+    if (!selectedEventId) return;
+    if (!selectableItems.some((item) => item.eventId === selectedEventId)) {
+      setSelectedEventId(undefined);
+    }
+  }, [selectableItems, selectedEventId]);
+
+  const handleKeyDown = useCallback(
+    (evt: KeyboardEvent) => {
+      if (evt.metaKey || evt.ctrlKey || evt.altKey) return;
+      if (!timelineNavMode && !selectedEventId) return;
+
+      if (isKeyHotkey(['arrowup', 'arrowdown'], evt)) {
+        if (selectableItems.length === 0) return;
+        const moveUp = isKeyHotkey('arrowup', evt);
+        const currentIndex = selectedEventId
+          ? selectableItems.findIndex((item) => item.eventId === selectedEventId)
+          : -1;
+        const nextIndex =
+          currentIndex === -1
+            ? moveUp
+              ? selectableItems.length - 1
+              : 0
+            : Math.min(
+                Math.max(currentIndex + (moveUp ? -1 : 1), 0),
+                selectableItems.length - 1
+              );
+        const nextItem = selectableItems[nextIndex];
+
+        if (nextItem) {
+          setSelectedEventId(nextItem.eventId);
+          scrollToItem(nextItem.itemIndex, {
+            behavior: 'instant',
+            align: 'center',
+            stopInView: true,
+          });
+          if (timelineNavMode) onExitTimelineNav();
+        }
+
+        evt.preventDefault();
+        evt.stopPropagation();
+        return;
+      }
+
+      const action = actions.find(
+        ({ hotkey, requiresSelection }) =>
+          isKeyHotkey(hotkey, evt) && (!requiresSelection || !!selectedEventId)
+      );
+      if (action) {
+        evt.preventDefault();
+        evt.stopPropagation();
+        action.handler(selectedEventId);
+        if (action.clearsSelection) setSelectedEventId(undefined);
+        if (action.exitsNav) onExitTimelineNav();
+        return;
+      }
+
+      if (selectedEventId && isEditableActive?.()) {
+        setSelectedEventId(undefined);
+      }
+    },
+    [
+      actions,
+      isEditableActive,
+      onExitTimelineNav,
+      scrollToItem,
+      selectableItems,
+      selectedEventId,
+      timelineNavMode,
+    ]
+  );
+
+  return {
+    selectedEventId,
+    setSelectedEventId,
+    handleKeyDown,
+  };
+};

--- a/src/app/features/room/useRoomTimelineNav.ts
+++ b/src/app/features/room/useRoomTimelineNav.ts
@@ -1,13 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { isKeyHotkey } from 'is-hotkey';
 import { EventTimeline, MatrixEvent } from 'matrix-js-sdk';
 
-import {
-  getTimelineAndBaseIndex,
-  getTimelineRelativeIndex,
-  getTimelineEvent,
-} from './roomTimelineUtils';
 
 type ItemIndex = number;
 
@@ -21,20 +16,18 @@ export type TimelineSelectionAction = {
   requiresSelection?: boolean;
   clearsSelection?: boolean;
   exitsNav?: boolean;
-  handler: (eventId?: string) => void;
+  handler?: (eventId?: string) => void;
 };
 
 /**
  * Keyboard navigation/selection helper for room timelines.
  *
  * Notes:
- * - `getItems` must return absolute item indices that align with `linkedTimelines`.
  * - `shouldRenderEvent` should match the render logic, or selection may land on hidden events.
  * - `scrollToItem` is expected to support `align: 'center'` and `behavior: 'instant'`.
  */
 type TimelineSelectionContext = {
   timelineNavMode: boolean;
-  getItems: () => ItemIndex[];
   linkedTimelines: EventTimeline[];
   shouldRenderEvent: (mEvent: MatrixEvent) => boolean;
   scrollToItem: (
@@ -50,28 +43,44 @@ type TimelineSelectionContext = {
   timelineRevision?: number;
 };
 
-const getSelectableItems = (
-  getItems: TimelineSelectionContext['getItems'],
+const buildSelectableItems = (
   linkedTimelines: TimelineSelectionContext['linkedTimelines'],
   shouldRenderEvent: TimelineSelectionContext['shouldRenderEvent']
 ): TimelineSelectableItem[] => {
-  const items = getItems();
   const selectable: TimelineSelectableItem[] = [];
+  let baseIndex = 0;
 
-  items.forEach((itemIndex) => {
-    const [eventTimeline, baseIndex] = getTimelineAndBaseIndex(linkedTimelines, itemIndex);
-    if (!eventTimeline) return;
-    const mEvent = getTimelineEvent(
-      eventTimeline,
-      getTimelineRelativeIndex(itemIndex, baseIndex)
-    );
-    const mEventId = mEvent?.getId();
-    if (!mEvent || !mEventId) return;
-    if (!shouldRenderEvent(mEvent)) return;
-    selectable.push({ eventId: mEventId, itemIndex });
+  linkedTimelines.forEach((timeline) => {
+    const events = timeline.getEvents();
+    for (let index = 0; index < events.length; index += 1) {
+      const mEvent = events[index];
+      const eventId = mEvent.getId();
+      if (eventId && shouldRenderEvent(mEvent)) {
+        selectable.push({ eventId, itemIndex: baseIndex + index });
+      }
+    }
+    baseIndex += events.length;
   });
 
   return selectable;
+};
+
+const isSelectableEventId = (
+  eventId: string,
+  linkedTimelines: TimelineSelectionContext['linkedTimelines'],
+  shouldRenderEvent: TimelineSelectionContext['shouldRenderEvent']
+): boolean => {
+  for (let timelineIndex = linkedTimelines.length - 1; timelineIndex >= 0; timelineIndex -= 1) {
+    const timeline = linkedTimelines[timelineIndex];
+    const events = timeline.getEvents();
+    for (let eventIndex = events.length - 1; eventIndex >= 0; eventIndex -= 1) {
+      const mEvent = events[eventIndex];
+      if (mEvent.getId() === eventId) {
+        return shouldRenderEvent(mEvent);
+      }
+    }
+  }
+  return false;
 };
 
 export const useRoomTimelineNav = (
@@ -80,7 +89,6 @@ export const useRoomTimelineNav = (
 ) => {
   const {
     timelineNavMode,
-    getItems,
     linkedTimelines,
     shouldRenderEvent,
     scrollToItem,
@@ -90,17 +98,18 @@ export const useRoomTimelineNav = (
   } = context;
   const [selectedEventId, setSelectedEventId] = useState<string | undefined>();
 
-  const selectableItems = useMemo(
-    () => getSelectableItems(getItems, linkedTimelines, shouldRenderEvent),
-    [getItems, linkedTimelines, shouldRenderEvent, timelineRevision]
-  );
+  const getSelectableItems = useCallback(() => {
+    if (timelineRevision === -1) return [];
+    return buildSelectableItems(linkedTimelines, shouldRenderEvent);
+  }, [linkedTimelines, shouldRenderEvent, timelineRevision]);
 
   useEffect(() => {
     if (!selectedEventId) return;
-    if (!selectableItems.some((item) => item.eventId === selectedEventId)) {
+    if (timelineNavMode) return;
+    if (!isSelectableEventId(selectedEventId, linkedTimelines, shouldRenderEvent)) {
       setSelectedEventId(undefined);
     }
-  }, [selectableItems, selectedEventId]);
+  }, [selectedEventId, timelineNavMode, linkedTimelines, shouldRenderEvent, getSelectableItems]);
 
   const handleKeyDown = useCallback(
     (evt: KeyboardEvent | ReactKeyboardEvent) => {
@@ -109,20 +118,22 @@ export const useRoomTimelineNav = (
       if (!timelineNavMode && !selectedEventId) return;
 
       if (isKeyHotkey(['arrowup', 'arrowdown'], hotkeyEvent)) {
+        const selectableItems = getSelectableItems();
         if (selectableItems.length === 0) return;
         const moveUp = isKeyHotkey('arrowup', hotkeyEvent);
         const currentIndex = selectedEventId
           ? selectableItems.findIndex((item) => item.eventId === selectedEventId)
           : -1;
-        const nextIndex =
-          currentIndex === -1
-            ? moveUp
-              ? selectableItems.length - 1
-              : 0
-            : Math.min(
-                Math.max(currentIndex + (moveUp ? -1 : 1), 0),
-                selectableItems.length - 1
-              );
+        let nextIndex = 0;
+        if (currentIndex === -1) {
+          nextIndex = moveUp ? selectableItems.length - 1 : 0;
+        } else {
+          const delta = moveUp ? -1 : 1;
+          nextIndex = Math.min(
+            Math.max(currentIndex + delta, 0),
+            selectableItems.length - 1
+          );
+        }
         const nextItem = selectableItems[nextIndex];
 
         if (nextItem) {
@@ -147,7 +158,7 @@ export const useRoomTimelineNav = (
       if (action) {
         evt.preventDefault();
         evt.stopPropagation();
-        action.handler(selectedEventId);
+        action.handler?.(selectedEventId);
         if (action.clearsSelection) setSelectedEventId(undefined);
         if (action.exitsNav) onExitTimelineNav();
         return;
@@ -160,9 +171,9 @@ export const useRoomTimelineNav = (
     [
       actions,
       isEditableActive,
+      getSelectableItems,
       onExitTimelineNav,
       scrollToItem,
-      selectableItems,
       selectedEventId,
       timelineNavMode,
     ]

--- a/src/app/hooks/useKeyDown.ts
+++ b/src/app/hooks/useKeyDown.ts
@@ -1,10 +1,14 @@
 import { useEffect } from 'react';
 
-export const useKeyDown = (target: Window, callback: (evt: KeyboardEvent) => void) => {
+export const useKeyDown = (
+  target: Window,
+  callback: (evt: KeyboardEvent) => void,
+  options?: AddEventListenerOptions
+) => {
   useEffect(() => {
-    target.addEventListener('keydown', callback);
+    target.addEventListener('keydown', callback, options);
     return () => {
-      target.removeEventListener('keydown', callback);
+      target.removeEventListener('keydown', callback, options);
     };
-  }, [target, callback]);
+  }, [target, callback, options]);
 };

--- a/src/app/hooks/useKeyDown.ts
+++ b/src/app/hooks/useKeyDown.ts
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
 
 export const useKeyDown = (
-  target: Window,
+  target: EventTarget | null,
   callback: (evt: KeyboardEvent) => void,
   options?: AddEventListenerOptions
 ) => {
   useEffect(() => {
+    if (!target) return undefined;
     target.addEventListener('keydown', callback, options);
     return () => {
       target.removeEventListener('keydown', callback, options);


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

## Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### Motivation

- Make replying to a message fast without mouse use.
- Provide a clear, consistent keyboard navigation path from the composer to a target message.

### High‑level flow

- User presses Tab in the composer to enter timeline nav mode.
- ArrowUp/ArrowDown moves the selection through renderable events.
- Pressing “r” opens the reply composer for the selected event.
- Selection is cleared on exit, and input focus returns to the editor.

### What changed

- Added a timeline navigation mode entered from the composer with Tab.
- Implemented selection state and keyboard movement (ArrowUp/ArrowDown) across renderable timeline events.
- Added keyboard actions on the selection, including “r” to start a reply to the selected message (and Escape to exit).
- Highlighted the selected message and provided visual feedback when entering nav mode.
- Refactored timeline helpers into reusable utilities and a dedicated hook to keep the behaviour isolated and extensible.

The hook centralises keyboard behaviour so new selection actions (reactions, pin, etc.) can be added in one place.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) [**this change modifies the way that keyboard navigation works by default in the composer**]
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


## Key files modified
- `src/app/features/room/RoomInput.tsx`: enter/exit nav mode from the composer.
- `src/app/features/room/RoomView.tsx`: nav mode state wiring.
- `src/app/features/room/RoomTimeline.tsx`: selection rendering + reply action wiring.
- `src/app/features/room/useRoomTimelineNav.ts`: hook encapsulating nav/selection logic.
- `src/app/features/room/roomTimelineUtils.ts`: shared timeline index helpers.
- `src/app/features/room/message/Message.tsx`: selected message styling.



