### PR TITLE
Fix space room reorder

### DIFF
--- a/src/app/features/lobby/Lobby.tsx
+++ b/src/app/features/lobby/Lobby.tsx
@@ -327,7 +327,7 @@ export function Lobby() {
 
         const itemSpaces = Array.from(
           hierarchy?.find((i) => i.space.roomId === containerParentId)?.rooms ?? []
-        );
+        ).filter((i) => i.roomId !== item.roomId);
 
         const beforeItem: HierarchyItem | undefined =
           'space' in containerItem ? undefined : containerItem;


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description

- Prevent duplicate entries during same-space drag reorder by removing the dragged room before reinserting
- Ensure a single `m.space.child` update per room when reordering within a space
- This issue manifested itself as failing to update space room ordering when dragging a room upwards for the first time


Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
