### PR TITLE
Fix muted rooms showing unread badges

### DIFF
--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -160,7 +160,8 @@ export const getOrphanParents = (roomToParents: RoomToParents, roomId: string): 
 };
 
 export const isMutedRule = (rule: IPushRule) =>
-  rule.actions[0] === 'dont_notify' && rule.conditions?.[0]?.kind === 'event_match';
+  // Check for empty actions (new spec) or dont_notify (deprecated)
+  (rule.actions.length === 0 || rule.actions[0] === 'dont_notify') && rule.conditions?.[0]?.kind === 'event_match';
 
 export const findMutedRule = (overrideRules: IPushRule[], roomId: string) =>
   overrideRules.find((rule) => rule.rule_id === roomId && isMutedRule(rule));


### PR DESCRIPTION
The mute detection was checking for `actions[0] === "dont_notify"` but Cinny sets `actions: []` (empty array) when muting a room, which is the correct behavior per Matrix spec where empty actions means no notification.

This caused muted rooms to still show unread badges and contribute to space badge counts.

Fixes the `isMutedRule` check to handle both:
- Empty actions array (current Matrix spec)
- `"dont_notify"` string (deprecated but may exist in older rules)

Fixes #2582