### PR TITLE
Fix MentionsAndKeywords rooms showing badges for all messages

### DIFF
--- a/src/app/state/room/roomToUnread.ts
+++ b/src/app/state/room/roomToUnread.ts
@@ -4,6 +4,7 @@ import {
   IRoomTimelineData,
   MatrixClient,
   MatrixEvent,
+  NotificationCountType,
   Room,
   RoomEvent,
   SyncState,
@@ -204,7 +205,10 @@ export const useBindRoomToUnreadAtom = (mx: MatrixClient, unreadAtom: typeof roo
       data: IRoomTimelineData
     ) => {
       if (!room || !data.liveEvent || room.isSpaceRoom() || !isNotificationEvent(mEvent)) return;
-      if (getNotificationType(mx, room.roomId) === NotificationType.Mute) {
+
+      const notificationType = getNotificationType(mx, room.roomId);
+
+      if (notificationType === NotificationType.Mute) {
         setUnreadAtom({
           type: 'DELETE',
           roomId: room.roomId,
@@ -213,6 +217,21 @@ export const useBindRoomToUnreadAtom = (mx: MatrixClient, unreadAtom: typeof roo
       }
 
       if (mEvent.getSender() === mx.getUserId()) return;
+
+      // For MentionsAndKeywords, only show badge for highlights (mentions)
+      if (notificationType === NotificationType.MentionsAndKeywords) {
+        const highlight = room.getUnreadNotificationCount(NotificationCountType.Highlight);
+        if (highlight > 0) {
+          setUnreadAtom({
+            type: 'PUT',
+            unreadInfo: { roomId: room.roomId, highlight, total: highlight },
+          });
+        } else {
+          setUnreadAtom({ type: 'DELETE', roomId: room.roomId });
+        }
+        return;
+      }
+
       setUnreadAtom({ type: 'PUT', unreadInfo: getUnreadInfo(room) });
     };
     mx.on(RoomEvent.Timeline, handleTimelineEvent);

--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -245,7 +245,17 @@ export const getUnreadInfos = (mx: MatrixClient): UnreadInfo[] => {
   const unreadInfos = mx.getRooms().reduce<UnreadInfo[]>((unread, room) => {
     if (room.isSpaceRoom()) return unread;
     if (room.getMyMembership() !== 'join') return unread;
-    if (getNotificationType(mx, room.roomId) === NotificationType.Mute) return unread;
+    const notificationType = getNotificationType(mx, room.roomId);
+    if (notificationType === NotificationType.Mute) return unread;
+
+    // For MentionsAndKeywords rooms, only show badge for highlights (mentions)
+    if (notificationType === NotificationType.MentionsAndKeywords) {
+      const highlight = room.getUnreadNotificationCount(NotificationCountType.Highlight);
+      if (highlight > 0) {
+        unread.push({ roomId: room.roomId, highlight, total: highlight });
+      }
+      return unread;
+    }
 
     if (roomHaveNotification(room) || roomHaveUnread(mx, room)) {
       unread.push(getUnreadInfo(room));


### PR DESCRIPTION
### Description

Fixes #2583

Rooms set to "Mentions and Keywords" notification mode now correctly show badges only when there are actual highlights (mentions), not for all unread messages.

### Changes

In `getUnreadInfos()` (`src/app/utils/room.ts`):
- Extract `notificationType` to a variable for reuse
- Add check for `MentionsAndKeywords` notification type
- For MentionsAndKeywords rooms, only add to unread list if `highlight > 0`
- Use highlight count as both highlight and total (since only mentions matter)

### Before

- MentionsAndKeywords rooms showed badge when `total > 0` (any message)
- Badge displayed `total` count (all unreads)

### After

- MentionsAndKeywords rooms show badge only when `highlight > 0` (actual mentions)
- Badge displays `highlight` count (only mentions)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings