### PR TITLE
feat: add option to only notify for participated threads

### DIFF
--- a/src/app/features/settings/notifications/SystemNotification.tsx
+++ b/src/app/features/settings/notifications/SystemNotification.tsx
@@ -91,6 +91,10 @@ export function SystemNotification() {
     settingsAtom,
     'isNotificationSounds'
   );
+  const [onlyParticipatedThreads, setOnlyParticipatedThreads] = useSetting(
+    settingsAtom,
+    'onlyParticipatedThreads'
+  );
 
   const requestNotificationPermission = () => {
     window.Notification.requestPermission();
@@ -143,6 +147,23 @@ export function SystemNotification() {
           title="Notification Sound"
           description="Play sound when new message arrive."
           after={<Switch value={isNotificationSounds} onChange={setIsNotificationSounds} />}
+        />
+      </SequenceCard>
+      <SequenceCard
+        className={SequenceCardStyle}
+        variant="SurfaceVariant"
+        direction="Column"
+        gap="400"
+      >
+        <SettingTile
+          title="Thread Notifications"
+          description="Only notify for threads you have participated in."
+          after={
+            <Switch
+              value={onlyParticipatedThreads}
+              onChange={setOnlyParticipatedThreads}
+            />
+          }
         />
       </SequenceCard>
       <SequenceCard

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue } from 'jotai';
 import React, { ReactNode, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { RoomEvent, RoomEventHandlerMap } from 'matrix-js-sdk';
+import { RelationType, RoomEvent, RoomEventHandlerMap } from 'matrix-js-sdk';
 import { roomToUnreadAtom, unreadEqual, unreadInfoToUnread } from '../../state/room/roomToUnread';
 import LogoSVG from '../../../../public/res/svg/cinny.svg';
 import LogoUnreadSVG from '../../../../public/res/svg/cinny-unread.svg';
@@ -136,6 +136,7 @@ function MessageNotifications() {
   const useAuthentication = useMediaAuthentication();
   const [showNotifications] = useSetting(settingsAtom, 'showNotifications');
   const [notificationSound] = useSetting(settingsAtom, 'isNotificationSounds');
+  const [onlyParticipatedThreads] = useSetting(settingsAtom, 'onlyParticipatedThreads');
 
   const navigate = useNavigate();
   const notificationSelected = useInboxNotificationsSelected();
@@ -177,6 +178,29 @@ function MessageNotifications() {
     audioElement?.play();
   }, []);
 
+  /**
+   * Check if the user has participated in a thread by scanning the thread timeline
+   * for events sent by the current user.
+   */
+  const hasUserParticipatedInThread = useCallback(
+    (roomId: string, threadRootEventId: string): boolean => {
+      const room = mx.getRoom(roomId);
+      if (!room) return false;
+
+      const thread = room.getThread(threadRootEventId);
+      if (!thread) return false;
+
+      const userId = mx.getUserId();
+      if (!userId) return false;
+
+      // Check if user sent any events in the thread timeline
+      const timeline = thread.timelineSet.getLiveTimeline();
+      const events = timeline.getEvents();
+      return events.some((event) => event.getSender() === userId);
+    },
+    [mx]
+  );
+
   useEffect(() => {
     const handleTimelineEvent: RoomEventHandlerMap[RoomEvent.Timeline] = (
       mEvent,
@@ -200,6 +224,17 @@ function MessageNotifications() {
       const sender = mEvent.getSender();
       const eventId = mEvent.getId();
       if (!sender || !eventId || mEvent.getSender() === mx.getUserId()) return;
+
+      // Check if this is a thread reply and filter based on participation
+      const relation = mEvent.getRelation();
+      if (onlyParticipatedThreads && relation?.rel_type === RelationType.Thread) {
+        const threadRootEventId = relation.event_id;
+        if (threadRootEventId && !hasUserParticipatedInThread(room.roomId, threadRootEventId)) {
+          // User hasn't participated in this thread, skip notification
+          return;
+        }
+      }
+
       const unreadInfo = getUnreadInfo(room);
       const cachedUnreadInfo = unreadCacheRef.current.get(room.roomId);
       unreadCacheRef.current.set(room.roomId, unreadInfo);
@@ -239,6 +274,8 @@ function MessageNotifications() {
     notificationSound,
     notificationSelected,
     showNotifications,
+    onlyParticipatedThreads,
+    hasUserParticipatedInThread,
     playSound,
     notify,
     selectedRoomId,

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -35,6 +35,7 @@ export interface Settings {
   legacyUsernameColor: boolean;
 
   showNotifications: boolean;
+  onlyParticipatedThreads: boolean;
   isNotificationSounds: boolean;
 
   hour24Clock: boolean;
@@ -69,6 +70,7 @@ const defaultSettings: Settings = {
   legacyUsernameColor: false,
 
   showNotifications: true,
+  onlyParticipatedThreads: false,
   isNotificationSounds: true,
 
   hour24Clock: false,


### PR DESCRIPTION
### Description

Fixes #2585

Adds a new setting "Thread Notifications" that when enabled, only shows notifications for thread replies in threads the user has participated in. This mimics Slack behavior.

### Changes

**`src/app/state/settings.ts`**
- Add `onlyParticipatedThreads: boolean` setting (default: false)

**`src/app/features/settings/notifications/SystemNotification.tsx`**
- Add toggle for "Thread Notifications" setting

**`src/app/pages/client/ClientNonUIFeatures.tsx`**
- Import `RelationType` from matrix-js-sdk
- Add `hasUserParticipatedInThread` helper function
- In `handleTimelineEvent`, check if event is thread reply and filter based on participation

### How it works

1. When a notification event comes in, check if its `rel_type` is `m.thread`
2. If the setting is enabled and its a thread reply:
   - Get the thread from the room using the thread root event ID
   - Scan the threads timeline for any events sent by the current user
   - If user hasnt participated, skip the notification
3. Non-thread messages and threads where user has participated notify normally

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings