### PR TITLE
fix: prevent phantom badges in bridged rooms

### DIFF
--- a/src/app/utils/room.ts
+++ b/src/app/utils/room.ts
@@ -248,7 +248,12 @@ export const getUnreadInfos = (mx: MatrixClient): UnreadInfo[] => {
     if (getNotificationType(mx, room.roomId) === NotificationType.Mute) return unread;
 
     if (roomHaveNotification(room) || roomHaveUnread(mx, room)) {
-      unread.push(getUnreadInfo(room));
+      const info = getUnreadInfo(room);
+      // Only show badge if server actually reports notifications
+      // This prevents phantom badges in bridged rooms where read receipts don't sync
+      if (info.total > 0 || info.highlight > 0) {
+        unread.push(info);
+      }
     }
 
     return unread;


### PR DESCRIPTION
Fixes #2589

Fixes phantom unread badges appearing in bridged rooms (e.g., Slack, Discord bridges) where read receipts do not sync back to Matrix.

## Problem
When using bridged rooms, reading messages on the other side (e.g., in Slack) does not update the Matrix read receipt. This causes `roomHaveUnread()` to return `true` even when the server notification count is 0, resulting in phantom badges.

## Solution
Make the server notification count authoritative. Only add a room to the unread list if the server actually reports notifications (`total > 0` or `highlight > 0`). This prevents phantom badges while still respecting the server's notification state.

## Testing
1. Set up a bridged room (e.g., Slack bridge)
2. Read messages on the bridge side (not in Cinny)
3. Refresh Cinny
4. Previously: phantom badge would appear
5. Now: no badge if server reports 0 notifications
