### PR TITLE
Centered login page dialog and updated the padding

### DIFF
--- a/src/app/pages/auth/AuthLayout.tsx
+++ b/src/app/pages/auth/AuthLayout.tsx
@@ -128,7 +128,7 @@ export function AuthLayout() {
         className={classNames(css.AuthLayout, PatternsCss.BackgroundDotPattern)}
         direction="Column"
         alignItems="Center"
-        justifyContent="SpaceBetween"
+        justifyContent="Center"
         gap="400"
       >
         <Box direction="Column" className={css.AuthCard}>

--- a/src/app/pages/auth/styles.css.ts
+++ b/src/app/pages/auth/styles.css.ts
@@ -6,13 +6,17 @@ export const AuthLayout = style({
   backgroundColor: color.Background.Container,
   color: color.Background.OnContainer,
   padding: config.space.S400,
-  paddingRight: config.space.S200,
-  paddingBottom: 0,
+  paddingBottom: config.space.S400,
   position: 'relative',
+  '@media': {
+    'screen and (max-width: 768px)': {
+      padding: config.space.S300,
+      paddingBottom: config.space.S300,
+    },
+  },
 });
 
 export const AuthCard = style({
-  marginTop: '1vh',
   maxWidth: toRem(460),
   width: '100%',
   backgroundColor: color.Surface.Container,
@@ -21,6 +25,12 @@ export const AuthCard = style({
   boxShadow: config.shadow.E100,
   border: `${config.borderWidth.B300} solid ${color.Surface.ContainerLine}`,
   overflow: 'hidden',
+  '@media': {
+    'screen and (max-width: 768px)': {
+      borderRadius: config.radii.R300,
+      maxWidth: '100%',
+    },
+  },
 });
 
 export const AuthLogo = style([
@@ -46,8 +56,20 @@ export const AuthCardContent = style({
   paddingTop: config.space.S700,
   paddingBottom: toRem(44),
   gap: toRem(44),
+  '@media': {
+    'screen and (max-width: 768px)': {
+      padding: config.space.S300,
+      paddingTop: config.space.S500,
+      paddingBottom: config.space.S500,
+      gap: config.space.S500,
+    },
+  },
 });
 
 export const AuthFooter = style({
   padding: config.space.S200,
+  position: 'absolute',
+  bottom: 0,
+  left: 0,
+  right: 0,
 });


### PR DESCRIPTION
### Description
- centered the login modal vertically
- updated mobile layout to not use `1vh`for the top margin
- made the padding identical on all sides (right side had smaller padding than the rest, was bugging me)

<details>
<summary>Desktop</summary>
Current

<img width="2542" height="1332" alt="Screenshot From 2026-02-11 21-09-08" src="https://github.com/user-attachments/assets/31d4aca3-b1eb-4c6d-8edb-56402edbedf3" />

Proposed

<img width="2542" height="1332" alt="Screenshot From 2026-02-11 21-09-00" src="https://github.com/user-attachments/assets/526dc341-77a6-45dc-a5a4-1507117dcaa6" />

</details>

<details>
<summary>Mobile</summary>

Current

<img width="498" height="1332" alt="Screenshot From 2026-02-11 21-09-21" src="https://github.com/user-attachments/assets/fd696cc5-ef5e-4a5a-a658-bf3859da9f2d" />


Proposed

<img width="498" height="1332" alt="Screenshot From 2026-02-11 21-09-38" src="https://github.com/user-attachments/assets/04a4cfa4-8b89-4ac5-a43b-65daf4d437ef" />


</details>



#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
