### PR TITLE
Replace envs.net with unredacted.org in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "defaultHomeserver": 2,
   "homeserverList": [
     "converser.eu",
-    "envs.net",
+    "unredacted.org",
     "matrix.org",
     "monero.social",
     "mozilla.org",
@@ -15,7 +15,7 @@
     "spaces": [
       "#cinny-space:matrix.org",
       "#community:matrix.org",
-      "#space:envs.net",
+      "#space:unredacted.org",
       "#science-space:matrix.org",
       "#libregaming-games:tchncs.de",
       "#mathematics-on:matrix.org"
@@ -28,7 +28,7 @@
       "#PrivSec.dev:arcticfoxes.net",
       "#disroot:aria-net.org"
     ],
-    "servers": ["envs.net", "matrix.org", "monero.social", "mozilla.org"]
+    "servers": ["unredacted.org", "matrix.org", "monero.social", "mozilla.org"]
   },
 
   "hashRouter": {

--- a/config.json
+++ b/config.json
@@ -1,11 +1,11 @@
 {
-  "defaultHomeserver": 2,
+  "defaultHomeserver": 1,
   "homeserverList": [
     "converser.eu",
-    "unredacted.org",
     "matrix.org",
     "monero.social",
     "mozilla.org",
+    "unredacted.org",
     "xmr.se"
   ],
   "allowCustomHomeservers": true,
@@ -28,7 +28,7 @@
       "#PrivSec.dev:arcticfoxes.net",
       "#disroot:aria-net.org"
     ],
-    "servers": ["unredacted.org", "matrix.org", "monero.social", "mozilla.org"]
+    "servers": [ "matrix.org", "monero.social", "mozilla.org", "unredacted.org" ]
   },
 
   "hashRouter": {

--- a/config.json
+++ b/config.json
@@ -3,7 +3,6 @@
   "homeserverList": [
     "converser.eu",
     "matrix.org",
-    "monero.social",
     "mozilla.org",
     "unredacted.org",
     "xmr.se"
@@ -28,7 +27,7 @@
       "#PrivSec.dev:arcticfoxes.net",
       "#disroot:aria-net.org"
     ],
-    "servers": [ "matrix.org", "monero.social", "mozilla.org", "unredacted.org" ]
+    "servers": [ "matrix.org", "mozilla.org", "unredacted.org" ]
   },
 
   "hashRouter": {


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

https://envs.net/ is shutting down their Matrix server on March 1st. I propose replacing it with unredacted.org which has been running a stable service since 2021.

Unredacted is a 501(c)(3) non-profit organization that builds Internet infrastructure and services to help people access the open Internet and protect their right to privacy.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
