### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy-pull-request.yml
+++ b/.github/workflows/deploy-pull-request.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download pr number
-        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
+        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05  # v14
         with:
           workflow: ${{ github.event.workflow.id }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -24,7 +24,7 @@ jobs:
         id: pr
         run: echo "id=$(<pr.txt)" >> $GITHUB_OUTPUT
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
+        uses: dawidd6/action-download-artifact@5c98f0b039f36ef966fdb7dfa9779262785ecb05  # v14
         with:
           workflow: ${{ github.event.workflow.id }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -45,7 +45,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_PR_CINNY }}
         timeout-minutes: 1
       - name: Comment preview on PR
-        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b  # v3.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.0
       - name: Build Docker image
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6.19.2
         with:
           context: .
           push: false

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -52,7 +52,7 @@ jobs:
           gpg --export | xxd -p
           echo '${{ secrets.GNUPG_PASSPHRASE }}' | gpg --batch --yes --pinentry-mode loopback --passphrase-fd 0 --armor --detach-sign cinny-${{ steps.vars.outputs.tag }}.tar.gz
       - name: Upload tagged release
-        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
         with:
           files: |
             cinny-${{ steps.vars.outputs.tag }}.tar.gz
@@ -68,29 +68,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.6.0
+        uses: docker/setup-qemu-action@v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.11.1
+        uses: docker/setup-buildx-action@v3.12.0
       - name: Login to Docker Hub
-        uses: docker/login-action@v3.6.0
+        uses: docker/login-action@v3.7.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to the Container registry
-        uses: docker/login-action@v3.6.0
+        uses: docker/login-action@v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5.8.0
+        uses: docker/metadata-action@v5.10.0
         with:
           images: |
             ${{ secrets.DOCKER_USERNAME }}/cinny
             ghcr.io/${{ github.repository }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6.19.2
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `dawidd6/action-download-artifact` | [`ac66b43`](https://github.com/dawidd6/action-download-artifact/commit/ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5) | [`5c98f0b`](https://github.com/dawidd6/action-download-artifact/commit/5c98f0b039f36ef966fdb7dfa9779262785ecb05) | [Release](https://github.com/dawidd6/action-download-artifact/releases/tag/v14) | deploy-pull-request.yml |
| `docker/build-push-action` | [`v6.18.0`](https://github.com/docker/build-push-action/releases/tag/v6.18.0) | [`v6.19.2`](https://github.com/docker/build-push-action/releases/tag/v6.19.2) | [Release](https://github.com/docker/build-push-action/releases/tag/v6) | docker-pr.yml, prod-deploy.yml |
| `docker/login-action` | [`v3.6.0`](https://github.com/docker/login-action/releases/tag/v3.6.0) | [`v3.7.0`](https://github.com/docker/login-action/releases/tag/v3.7.0) | [Release](https://github.com/docker/login-action/releases/tag/v3) | prod-deploy.yml |
| `docker/metadata-action` | [`v5.8.0`](https://github.com/docker/metadata-action/releases/tag/v5.8.0) | [`v5.10.0`](https://github.com/docker/metadata-action/releases/tag/v5.10.0) | [Release](https://github.com/docker/metadata-action/releases/tag/v5) | prod-deploy.yml |
| `docker/setup-buildx-action` | [`v3.11.1`](https://github.com/docker/setup-buildx-action/releases/tag/v3.11.1) | [`v3.12.0`](https://github.com/docker/setup-buildx-action/releases/tag/v3.12.0) | [Release](https://github.com/docker/setup-buildx-action/releases/tag/v3) | prod-deploy.yml |
| `docker/setup-qemu-action` | [`v3.6.0`](https://github.com/docker/setup-qemu-action/releases/tag/v3.6.0) | [`v3.7.0`](https://github.com/docker/setup-qemu-action/releases/tag/v3.7.0) | [Release](https://github.com/docker/setup-qemu-action/releases/tag/v3) | prod-deploy.yml |
| `softprops/action-gh-release` | [`6cbd405`](https://github.com/softprops/action-gh-release/commit/6cbd405e2c4e67a21c47fa9e383d020e4e28b836) | [`a06a81a`](https://github.com/softprops/action-gh-release/commit/a06a81a03ee405af7f2048a818ed3f03bbf83c7b) | [Release](https://github.com/softprops/action-gh-release/releases/tag/v2) | prod-deploy.yml |
| `thollander/actions-comment-pull-request` | [`fabd468`](https://github.com/thollander/actions-comment-pull-request/commit/fabd468d3a1a0b97feee5f6b9e499eab0dd903f6) | [`24bffb9`](https://github.com/thollander/actions-comment-pull-request/commit/24bffb9b452ba05a4f3f77933840a6a841d1b32b) | [Release](https://github.com/thollander/actions-comment-pull-request/releases/tag/v3) | deploy-pull-request.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
