### PR TITLE
fix: change blockquotes and actions (m.emote) to not render as cursive

### DIFF
--- a/src/app/components/message/layout/layout.css.ts
+++ b/src/app/components/message/layout/layout.css.ts
@@ -198,7 +198,6 @@ export const MessageTextBody = recipe({
     emote: {
       true: {
         color: color.Success.Main,
-        fontStyle: 'italic',
       },
     },
   },

--- a/src/app/styles/CustomHtml.css.ts
+++ b/src/app/styles/CustomHtml.css.ts
@@ -37,7 +37,6 @@ export const BlockQuote = style([
   {
     paddingLeft: config.space.S200,
     borderLeft: `${config.borderWidth.B700} solid ${color.SurfaceVariant.ContainerLine}`,
-    fontStyle: 'italic',
   },
 ]);
 


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR removes `italic` fontStyle from BlockQuote and MessageTextBody (m.emote)


Fixes #2553

notes: i assume there's no other place in the source using `italic` (except for ReactPrism)

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
