### PR TITLE
fix: add noreferrer to sanitized links for improved privacy consistency

### DIFF
--- a/src/app/utils/sanitize.ts
+++ b/src/app/utils/sanitize.ts
@@ -100,7 +100,7 @@ const transformATag: Transformer = (tagName, attribs) => ({
   tagName,
   attribs: {
     ...attribs,
-    rel: 'noopener',
+    rel: 'noreferrer noopener',
     target: '_blank',
   },
 });
@@ -112,7 +112,7 @@ const transformImgTag: Transformer = (tagName, attribs) => {
       tagName: 'a',
       attribs: {
         href: src,
-        rel: 'noopener',
+        rel: 'noreferrer noopener',
         target: '_blank',
       },
       text: attribs.alt || src,


### PR DESCRIPTION
Enhancing user privacy by adding `noreferrer` to links and images transformed during the HTML sanitization process is the main focus here.

Currently, `src/app/utils/sanitize.ts` only applies `rel="noopener"`, which handles security against window hijacking but still allows the instance's URL to be leaked via the `Referer` header. Adding `noreferrer` aligns this module with existing privacy-focused patterns used in other parts of the project, such as `LINKIFY_OPTS` and `renderMatrixMention`.

Codebase consistency is improved, ensuring that all user-generated links follow the same strict privacy standards.

Verification confirmed that the changes do not interfere with internal room navigation or specialized matrix schemes. Formatting was checked using Prettier.