### PR TITLE
Add persistent local storage drafts for room input

### DIFF
--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -28,7 +28,7 @@ import {
   config,
   toRem,
 } from 'folds';
-
+import { RESET } from 'jotai/utils';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import {
   CustomEditor,
@@ -117,6 +117,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { useRoomCreatorsTag } from '../../hooks/useRoomCreatorsTag';
 import { usePowerLevelTags } from '../../hooks/usePowerLevelTags';
 import { useComposingCheck } from '../../hooks/useComposingCheck';
+import { useDebounce } from '../../hooks/useDebounce';
 
 interface RoomInputProps {
   editor: Editor;
@@ -226,21 +227,38 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     );
 
     useEffect(() => {
-      Transforms.insertFragment(editor, msgDraft);
+      // if the editor is empty and there is a draft, restore it
+      if (isEmptyEditor(editor) && msgDraft && msgDraft.length > 0) {
+        Transforms.insertFragment(editor, msgDraft);
+      }
     }, [editor, msgDraft]);
 
+    // On unmount, if the editor is not empty, save the draft. Otherwise, clear the draft.
     useEffect(
       () => () => {
         if (!isEmptyEditor(editor)) {
           const parsedDraft = JSON.parse(JSON.stringify(editor.children));
           setMsgDraft(parsedDraft);
         } else {
-          setMsgDraft([]);
+          setMsgDraft(RESET);
         }
         resetEditor(editor);
         resetEditorHistory(editor);
       },
       [roomId, editor, setMsgDraft]
+    );
+
+    // Save draft after the editor changes
+    const handleAutomaticDraftSave = useDebounce(
+      () => {
+        if (!isEmptyEditor(editor)) {
+          const parsedDraft = JSON.parse(JSON.stringify(editor.children));
+          setMsgDraft(parsedDraft);
+        } else {
+          setMsgDraft(RESET);
+        }
+      },
+      { wait: 400 }
     );
 
     const handleFileMetadata = useCallback(
@@ -543,6 +561,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           onKeyDown={handleKeyDown}
           onKeyUp={handleKeyUp}
           onPaste={handlePaste}
+          onChange={handleAutomaticDraftSave}
           top={
             replyDraft && (
               <div>

--- a/src/app/state/room/roomInputDrafts.ts
+++ b/src/app/state/room/roomInputDrafts.ts
@@ -1,5 +1,4 @@
-import { atom } from 'jotai';
-import { atomFamily } from 'jotai/utils';
+import { atomFamily, atomWithStorage } from 'jotai/utils';
 import { Descendant } from 'slate';
 import { EncryptedAttachmentInfo } from 'browser-encrypt-attachment';
 import { IEventRelation } from 'matrix-js-sdk';
@@ -20,9 +19,7 @@ export type TUploadItem = {
 
 export type TUploadListAtom = ReturnType<typeof createListAtom<TUploadItem>>;
 
-export const roomIdToUploadItemsAtomFamily = atomFamily<string, TUploadListAtom>(
-  createListAtom
-);
+export const roomIdToUploadItemsAtomFamily = atomFamily<string, TUploadListAtom>(createListAtom);
 
 export const roomUploadAtomFamily = createUploadAtomFamily();
 
@@ -37,10 +34,11 @@ export type RoomIdToMsgAction =
       roomId: string;
     };
 
-const createMsgDraftAtom = () => atom<Descendant[]>([]);
+const createMsgDraftAtom = (roomId: string) =>
+  atomWithStorage<Descendant[]>(`messageDraft-${roomId}`, []);
 export type TMsgDraftAtom = ReturnType<typeof createMsgDraftAtom>;
-export const roomIdToMsgDraftAtomFamily = atomFamily<string, TMsgDraftAtom>(() =>
-  createMsgDraftAtom()
+export const roomIdToMsgDraftAtomFamily = atomFamily<string, TMsgDraftAtom>((roomId) =>
+  createMsgDraftAtom(roomId)
 );
 
 export type IReplyDraft = {
@@ -50,8 +48,9 @@ export type IReplyDraft = {
   formattedBody?: string | undefined;
   relation?: IEventRelation | undefined;
 };
-const createReplyDraftAtom = () => atom<IReplyDraft | undefined>(undefined);
+const createReplyDraftAtom = (roomId: string) =>
+  atomWithStorage<IReplyDraft | undefined>(`replyDraft-${roomId}`, undefined);
 export type TReplyDraftAtom = ReturnType<typeof createReplyDraftAtom>;
-export const roomIdToReplyDraftAtomFamily = atomFamily<string, TReplyDraftAtom>(() =>
-  createReplyDraftAtom()
+export const roomIdToReplyDraftAtomFamily = atomFamily<string, TReplyDraftAtom>((roomId) =>
+  createReplyDraftAtom(roomId)
 );


### PR DESCRIPTION
### Description

This PR adds localStorage-based draft persistence to the message input. Drafts are saved automatically with a 400ms debounce whenever the editor content changes and are restored when the component mounts if the editor is empty.

When the component unmounts (or the room changes), the current editor content is saved if it is not empty. If the editor is empty, the stored draft is cleared. This prevents users from losing in-progress messages when refreshing the page and preserves drafts per room.

This issue was discussed in #2578 

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
