### PR TITLE
Change RoomUpgrade dialog to use current room version as initial selection

### DIFF
--- a/src/app/features/common-settings/general/RoomUpgrade.tsx
+++ b/src/app/features/common-settings/general/RoomUpgrade.tsx
@@ -46,13 +46,18 @@ function RoomUpgradeDialog({ requestClose }: { requestClose: () => void }) {
   const alive = useAlive();
   const creators = useRoomCreators(room);
 
+  const createEvent = useStateEvent(room, StateEvent.RoomCreate);
+  const createContent = createEvent?.getContent() as IRoomCreateContent | undefined;
+  const currentRoomVersion = createContent?.room_version ?? '1';
   const capabilities = useCapabilities();
   const roomVersions = capabilities['m.room_versions'];
-  const [selectedRoomVersion, selectRoomVersion] = useState(roomVersions?.default ?? '1');
+  const [selectedRoomVersion, selectRoomVersion] = useState(currentRoomVersion);
+
   useEffect(() => {
-    // capabilities load async
-    selectRoomVersion(roomVersions?.default ?? '1');
-  }, [roomVersions?.default]);
+    if (currentRoomVersion) {
+      selectRoomVersion(currentRoomVersion);
+    }
+  }, [currentRoomVersion]);
 
   const allowAdditionalCreators = creatorsSupported(selectedRoomVersion);
   const { additionalCreators, addAdditionalCreator, removeAdditionalCreator } =


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
The Room Upgrade dialog would default to the server's recommended version (e.g., v10) even if the room was already on a newer version (e.g., v12).

#### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
