### PR TITLE
Add current room and space name to title

### DIFF
--- a/src/app/features/settings/general/General.tsx
+++ b/src/app/features/settings/general/General.tsx
@@ -306,6 +306,7 @@ function PageZoomInput() {
 function Appearance() {
   const [systemTheme, setSystemTheme] = useSetting(settingsAtom, 'useSystemTheme');
   const [monochromeMode, setMonochromeMode] = useSetting(settingsAtom, 'monochromeMode');
+  const [dynamicPageTitle, setDynamicPageTitle] = useSetting(settingsAtom, 'showDynamicPageTitle');
   const [twitterEmoji, setTwitterEmoji] = useSetting(settingsAtom, 'twitterEmoji');
 
   return (
@@ -337,6 +338,16 @@ function Appearance() {
         <SettingTile
           title="Monochrome Mode"
           after={<Switch variant="Primary" value={monochromeMode} onChange={setMonochromeMode} />}
+        />
+      </SequenceCard>
+
+      <SequenceCard className={SequenceCardStyle} variant="SurfaceVariant" direction="Column">
+        <SettingTile
+          title="Dynamic Page Title"
+          description="Display your curent Room/Space in your window title."
+          after={
+            <Switch variant="Primary" value={dynamicPageTitle} onChange={setDynamicPageTitle} />
+          }
         />
       </SequenceCard>
 

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -8,7 +8,7 @@ import LogoUnreadSVG from '../../../../public/res/svg/cinny-unread.svg';
 import LogoHighlightSVG from '../../../../public/res/svg/cinny-highlight.svg';
 import NotificationSound from '../../../../public/sound/notification.ogg';
 import InviteSound from '../../../../public/sound/invite.ogg';
-import { notificationPermission, setFavicon } from '../../utils/dom';
+import { notificationPermission, setFavicon, setTitle } from '../../utils/dom';
 import { useSetting } from '../../state/hooks/settings';
 import { settingsAtom } from '../../state/settings';
 import { allInvitesAtom } from '../../state/room-list/inviteList';
@@ -26,6 +26,7 @@ import { getMxIdLocalPart, mxcUrlToHttp } from '../../utils/matrix';
 import { useSelectedRoom } from '../../hooks/router/useSelectedRoom';
 import { useInboxNotificationsSelected } from '../../hooks/router/useInbox';
 import { useMediaAuthentication } from '../../hooks/useMediaAuthentication';
+import { useSelectedSpace } from '../../hooks/router/useSelectedSpace';
 
 function SystemEmojiFeature() {
   const [twitterEmoji] = useSetting(settingsAtom, 'twitterEmoji');
@@ -72,6 +73,32 @@ function FaviconUpdater() {
       setFavicon(LogoSVG);
     }
   }, [roomToUnread]);
+
+  return null;
+}
+
+function TitleUpdater() {
+  const mx = useMatrixClient();
+  const selectedRoomId = useSelectedRoom();
+  const selectedSpaceId = useSelectedSpace();
+  
+  useEffect(() => {
+    let title = 'Cinny | ';
+    if (selectedSpaceId) {
+      const space = mx.getRoom(selectedSpaceId);
+      title += space?.name ?? 'Unknown Space';
+    }
+    if (selectedRoomId) {
+      const room = mx.getRoom(selectedRoomId);
+      const roomName = room?.name ?? 'Unknown Room';
+      title += selectedSpaceId ? ` - #${roomName}` : `#${roomName}`;
+    }
+    if (!selectedRoomId && !selectedSpaceId) {
+      title = 'Cinny';
+    }
+
+    setTitle(title);
+  }, [mx, selectedRoomId, selectedSpaceId]);
 
   return null;
 }
@@ -263,6 +290,7 @@ export function ClientNonUIFeatures({ children }: ClientNonUIFeaturesProps) {
       <SystemEmojiFeature />
       <PageZoomFeature />
       <FaviconUpdater />
+      <TitleUpdater />
       <InviteNotifications />
       <MessageNotifications />
       {children}

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -79,26 +79,26 @@ function FaviconUpdater() {
 
 function TitleUpdater() {
   const mx = useMatrixClient();
-  const selectedRoomId = useSelectedRoom();
-  const selectedSpaceId = useSelectedSpace();
-  
+  const selectedSpace = useSelectedSpace();
+  const selectedRoom = useSelectedRoom();
+
   useEffect(() => {
+    const spaceName = selectedSpace ? mx.getRoom(selectedSpace)?.name : undefined;
+    const roomName = selectedRoom ? mx.getRoom(selectedRoom)?.name : undefined;
+
     let title = 'Cinny | ';
-    if (selectedSpaceId) {
-      const space = mx.getRoom(selectedSpaceId);
-      title += space?.name ?? 'Unknown Space';
+    if (spaceName) {
+      title += spaceName;
     }
-    if (selectedRoomId) {
-      const room = mx.getRoom(selectedRoomId);
-      const roomName = room?.name ?? 'Unknown Room';
-      title += selectedSpaceId ? ` - #${roomName}` : `#${roomName}`;
+    if (roomName) {
+      title += spaceName ? ` - #${roomName}` : `#${roomName}`;
     }
-    if (!selectedRoomId && !selectedSpaceId) {
+    if (!roomName && !spaceName) {
       title = 'Cinny';
     }
 
     setTitle(title);
-  }, [mx, selectedRoomId, selectedSpaceId]);
+  }, [mx, selectedRoom, selectedSpace]);
 
   return null;
 }

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -83,26 +83,22 @@ function TitleUpdater() {
   const selectedRoom = useSelectedRoom();
 
   useEffect(() => {
-    const spaceName = selectedSpace ? mx.getRoom(selectedSpace)?.name : undefined;
-    const roomName = selectedRoom ? mx.getRoom(selectedRoom)?.name : undefined;
+    const space = selectedSpace ? mx.getRoom(selectedSpace) : undefined;
+    const room = selectedRoom ? mx.getRoom(selectedRoom) : undefined;
 
-    let title = 'Cinny | ';
-    if (spaceName) {
-      title += spaceName;
-    }
-    if (roomName) {
-      title += spaceName ? ` - #${roomName}` : `#${roomName}`;
-    }
-    if (!roomName && !spaceName) {
-      title = 'Cinny';
-    }
+    const spaceName = space?.name || space?.roomId;
+    const roomName = room?.name || room?.roomId;
 
-    setTitle(title);
+    const parts: string[] = [];
+    if (roomName) parts.push(roomName);
+    if (spaceName) parts.push(spaceName);
+    parts.push('Cinny');
+
+    document.title = parts.join(' – ');
   }, [mx, selectedRoom, selectedSpace]);
 
   return null;
 }
-
 function InviteNotifications() {
   const audioRef = useRef<HTMLAudioElement>(null);
   const invites = useAtomValue(allInvitesAtom);

--- a/src/app/pages/client/ClientNonUIFeatures.tsx
+++ b/src/app/pages/client/ClientNonUIFeatures.tsx
@@ -8,7 +8,7 @@ import LogoUnreadSVG from '../../../../public/res/svg/cinny-unread.svg';
 import LogoHighlightSVG from '../../../../public/res/svg/cinny-highlight.svg';
 import NotificationSound from '../../../../public/sound/notification.ogg';
 import InviteSound from '../../../../public/sound/invite.ogg';
-import { notificationPermission, setFavicon, setTitle } from '../../utils/dom';
+import { notificationPermission, setFavicon } from '../../utils/dom';
 import { useSetting } from '../../state/hooks/settings';
 import { settingsAtom } from '../../state/settings';
 import { allInvitesAtom } from '../../state/room-list/inviteList';
@@ -281,12 +281,21 @@ type ClientNonUIFeaturesProps = {
 };
 
 export function ClientNonUIFeatures({ children }: ClientNonUIFeaturesProps) {
+  const [showDynamicPageTitle] = useSetting(settingsAtom, 'showDynamicPageTitle');
+  const defaultTitleRef = useRef(document.title);
+
+  useEffect(() => {
+    if (!showDynamicPageTitle && document.title !== defaultTitleRef.current) {
+      document.title = defaultTitleRef.current;
+    }
+  }, [showDynamicPageTitle]);
+
   return (
     <>
       <SystemEmojiFeature />
       <PageZoomFeature />
       <FaviconUpdater />
-      <TitleUpdater />
+      {showDynamicPageTitle && <TitleUpdater />}
       <InviteNotifications />
       <MessageNotifications />
       {children}

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -20,6 +20,7 @@ export interface Settings {
   twitterEmoji: boolean;
   pageZoom: number;
   hideActivity: boolean;
+  showDynamicPageTitle: boolean;
 
   isPeopleDrawer: boolean;
   memberSortFilterIndex: number;
@@ -54,6 +55,7 @@ const defaultSettings: Settings = {
   twitterEmoji: false,
   pageZoom: 100,
   hideActivity: false,
+  showDynamicPageTitle: false,
 
   isPeopleDrawer: true,
   memberSortFilterIndex: 0,

--- a/src/app/utils/dom.ts
+++ b/src/app/utils/dom.ts
@@ -211,6 +211,10 @@ export const setFavicon = (url: string): void => {
   favicon.setAttribute('href', url);
 };
 
+export const setTitle = (title?: string): void => {
+  document.title = title ?? 'Cinny';
+};
+
 export const tryDecodeURIComponent = (encodedURIComponent: string): string => {
   try {
     return decodeURIComponent(encodedURIComponent);

--- a/src/app/utils/dom.ts
+++ b/src/app/utils/dom.ts
@@ -211,10 +211,6 @@ export const setFavicon = (url: string): void => {
   favicon.setAttribute('href', url);
 };
 
-export const setTitle = (title?: string): void => {
-  document.title = title ?? 'Cinny';
-};
-
 export const tryDecodeURIComponent = (encodedURIComponent: string): string => {
   try {
     return decodeURIComponent(encodedURIComponent);


### PR DESCRIPTION
### Description
This PR adds a TitleUpdater component that changes the title of the browser tab dynamically based on the currently active room and space. With this feature, it is easier to distinguish between tabs when multiple rooms are open. This feature not only improves usability but also accessibility since assistive technologies depend on the correct title of the page to enable users to navigate through the page efficiently.

This addition was discussed in #2575 

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas **( Code is self documenting )**
- [ ] I have made corresponding changes to the documentation 
- [x] My changes generate no new warnings
