### PR TITLE
timeline: fix auto-scroll undershooting on tall messages

### DIFF
--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -498,6 +498,57 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
   atBottomRef.current = atBottom;
 
   const scrollRef = useRef<HTMLDivElement>(null);
+  const smoothScrollRef = useRef<{
+    rafId: number | null;
+    cancel: (() => void) | null;
+  }>({ rafId: null, cancel: null });
+
+  const cancelSmoothScroll = useCallback(() => {
+    const s = smoothScrollRef.current;
+    if (s.rafId !== null) {
+      cancelAnimationFrame(s.rafId);
+      s.rafId = null;
+    }
+    if (s.cancel) {
+      s.cancel();
+      s.cancel = null;
+    }
+  }, []);
+
+  const doSmoothScrollToBottom = useCallback(
+    (scrollEl: HTMLElement) => {
+      const s = smoothScrollRef.current;
+      // Let the running loop handle it, it picks up the new scrollHeight each frame.
+      if (s.rafId !== null) return;
+
+      const onUserScroll = () => cancelSmoothScroll();
+      scrollEl.addEventListener('wheel', onUserScroll, { passive: true });
+      scrollEl.addEventListener('touchstart', onUserScroll, { passive: true });
+      s.cancel = () => {
+        scrollEl.removeEventListener('wheel', onUserScroll);
+        scrollEl.removeEventListener('touchstart', onUserScroll);
+      };
+
+      const step = () => {
+        const target = scrollEl.scrollHeight - scrollEl.offsetHeight;
+        const current = scrollEl.scrollTop;
+        const remaining = target - current;
+
+        if (remaining <= 0.5) {
+          scrollEl.scrollTop = target;
+          cancelSmoothScroll();
+          return;
+        }
+
+        scrollEl.scrollTop = current + Math.max(remaining * 0.2, 1);
+        s.rafId = requestAnimationFrame(step);
+      };
+
+      s.rafId = requestAnimationFrame(step);
+    },
+    [cancelSmoothScroll]
+  );
+
   const scrollToBottomRef = useRef({
     count: 0,
     smooth: true,
@@ -854,10 +905,18 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
   useLayoutEffect(() => {
     if (scrollToBottomCount > 0) {
       const scrollEl = scrollRef.current;
-      if (scrollEl)
-        scrollToBottom(scrollEl, scrollToBottomRef.current.smooth ? 'smooth' : 'instant');
+      if (scrollEl) {
+        if (scrollToBottomRef.current.smooth) {
+          doSmoothScrollToBottom(scrollEl);
+        } else {
+          cancelSmoothScroll();
+          scrollToBottom(scrollEl, 'instant');
+        }
+      }
     }
-  }, [scrollToBottomCount]);
+  }, [doSmoothScrollToBottom, cancelSmoothScroll, scrollToBottomCount]);
+
+  useEffect(() => () => cancelSmoothScroll(), [cancelSmoothScroll]);
 
   // Remove unreadInfo on mark as read
   useEffect(() => {


### PR DESCRIPTION
### Description

When a tall message (a sticker, a long text block) arrives in an active
room, `useLiveEventArrive` fires and triggers `scrollToBottom(scrollEl,
'smooth')` from a layout effect. But reactions and read receipts from
other participants fire the same handler milliseconds later, and each
`scrollTo({behavior: 'smooth'})` call cancels the inflight CSS
animation and restarts from wherever the viewport has reached, usually
only a few pixels further. The scroll never converges, leaving the new
message partially off-screen.

This commit replaces the native smooth scroll with a
`requestAnimationFrame` loop that reads `scrollHeight - offsetHeight`
each frame and advances `scrollTop` by 20% of the remaining distance
(~230 ms to 95% at 60 fps). Subsequent live events are no-ops because
the running loop already chases the live bottom. `wheel` and
`touchstart` listeners cancel the animation so back-scrolling is
unaffected, and `cancelSmoothScroll` clears state for instant scrolls
on room switches.

- Fixes #2259

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings