### PR TITLE
Add deafen functionality

### DIFF
--- a/src/app/features/room-nav/RoomCallNavStatus.css.ts
+++ b/src/app/features/room-nav/RoomCallNavStatus.css.ts
@@ -5,14 +5,32 @@ export const Actions = style({
   padding: config.space.S200,
 });
 
-export const RoomButtonWrap = style({
-  minWidth: 0,
+export const VoiceAppear = style({
+  opacity: 0,
+  maxHeight: 0,
+  overflow: 'hidden',
+  transform: 'translateY(12px)',
+  transition: 'all 500ms cubic-bezier(0.4, 0, 0.2, 1)',
+
+  selectors: {
+    '&.active': {
+      opacity: 1,
+      maxHeight: '200px',
+      transform: 'translateY(0)',
+    },
+  },
 });
 
 export const RoomButton = style({
   width: '100%',
   minWidth: 0,
   padding: `0 ${config.space.S200}`,
+  justifyContent: 'space-between',
+});
+
+export const VoiceControls = style({
+  paddingBottom: 15,
+  justifyContent: 'center',
 });
 
 export const RoomName = style({

--- a/src/app/features/room-nav/RoomCallNavStatus.tsx
+++ b/src/app/features/room-nav/RoomCallNavStatus.tsx
@@ -20,11 +20,11 @@ export function CallNavStatus() {
   const {
     activeCallRoomId,
     isActiveCallReady,
-    isMicEnabled,
     isAudioEnabled,
+    isDeafened,
     isVideoEnabled,
-    toggleMic,
     toggleAudio,
+    toggleDeafened,
     toggleVideo,
     hangUp,
   } = useCallState();
@@ -102,13 +102,13 @@ export function CallNavStatus() {
           offset={4}
           tooltip={
             <Tooltip>
-              <Text>{!isMicEnabled ? 'Unmute' : 'Mute'}</Text>
+              <Text>{!isAudioEnabled ? 'Unmute' : 'Mute'}</Text>
             </Tooltip>
           }
         >
           {(triggerRef) => (
-            <IconButton fill="None" size="300" ref={triggerRef} onClick={toggleMic}>
-              <Icon src={!isMicEnabled ? Icons.MicMute : Icons.Mic} />
+            <IconButton fill="None" size="300" ref={triggerRef} onClick={toggleAudio}>
+              <Icon src={!isAudioEnabled ? Icons.MicMute : Icons.Mic} />
             </IconButton>
           )}
         </TooltipProvider>
@@ -117,13 +117,13 @@ export function CallNavStatus() {
           offset={4}
           tooltip={
             <Tooltip>
-              <Text>{!isAudioEnabled ? 'Undeafened' : 'Deafen'}</Text>
+              <Text>{!isDeafened ? 'Undeafened' : 'Deafen'}</Text>
             </Tooltip>
           }
         >
           {(triggerRef) => (
-            <IconButton fill="None" size="300" ref={triggerRef} onClick={toggleAudio}>
-              <Icon src={!isAudioEnabled ? Icons.HeadphoneMute : Icons.Headphone} />
+            <IconButton fill="None" size="300" ref={triggerRef} onClick={toggleDeafened}>
+              <Icon src={isDeafened ? Icons.HeadphoneMute : Icons.Headphone} />
             </IconButton>
           )}
         </TooltipProvider>

--- a/src/app/features/room-nav/RoomCallNavStatus.tsx
+++ b/src/app/features/room-nav/RoomCallNavStatus.tsx
@@ -20,8 +20,10 @@ export function CallNavStatus() {
   const {
     activeCallRoomId,
     isActiveCallReady,
+    isMicEnabled,
     isAudioEnabled,
     isVideoEnabled,
+    toggleMic,
     toggleAudio,
     toggleVideo,
     hangUp,
@@ -98,13 +100,28 @@ export function CallNavStatus() {
           offset={4}
           tooltip={
             <Tooltip>
-              <Text>{!isAudioEnabled ? 'Unmute' : 'Mute'}</Text>
+              <Text>{!isMicEnabled ? 'Unmute' : 'Mute'}</Text>
+            </Tooltip>
+          }
+        >
+          {(triggerRef) => (
+            <IconButton fill="None" size="300" ref={triggerRef} onClick={toggleMic}>
+              <Icon src={!isMicEnabled ? Icons.MicMute : Icons.Mic} />
+            </IconButton>
+          )}
+        </TooltipProvider>
+        <TooltipProvider
+          position="Top"
+          offset={4}
+          tooltip={
+            <Tooltip>
+              <Text>{!isAudioEnabled ? 'Undeafened' : 'Deafen'}</Text>
             </Tooltip>
           }
         >
           {(triggerRef) => (
             <IconButton fill="None" size="300" ref={triggerRef} onClick={toggleAudio}>
-              <Icon src={!isAudioEnabled ? Icons.MicMute : Icons.Mic} />
+              <Icon src={!isAudioEnabled ? Icons.HeadphoneMute : Icons.Headphone} />
             </IconButton>
           )}
         </TooltipProvider>

--- a/src/app/features/room-nav/RoomCallNavStatus.tsx
+++ b/src/app/features/room-nav/RoomCallNavStatus.tsx
@@ -41,8 +41,8 @@ export function CallNavStatus() {
     <Box direction="Column" shrink="No">
       <Line variant="Surface" size="300" />
       <Box className={css.Actions} direction="Row" alignItems="Center" gap="100">
-        <Box className={css.RoomButtonWrap} grow="Yes">
-          {hasActiveCall && (
+        <Box className={`${css.VoiceAppear} ${hasActiveCall ? 'active' : ''}`} grow="Yes">
+          <Chip size="500" fill="Soft" className={css.RoomButton}>
             <TooltipProvider
               position="Top"
               offset={4}
@@ -53,48 +53,50 @@ export function CallNavStatus() {
               }
             >
               {(triggerRef) => (
-                <Chip
-                  size="500"
-                  fill="Soft"
-                  as="button"
-                  onClick={handleGoToCallRoom}
-                  ref={triggerRef}
-                  className={css.RoomButton}
-                >
-                  {isConnected ? (
-                    <Icon size="300" src={Icons.VolumeHigh} style={{ color: color.Success.Main }} />
-                  ) : (
-                    <Spinner size="300" variant="Secondary" />
-                  )}
-                  <Text
-                    as="span"
-                    size="L400"
-                    style={{ color: isConnected ? color.Success.Main : color.Warning.Main }}
-                  >
-                    {isConnected ? 'Connected' : 'Connecting'}
-                  </Text>
-                </Chip>
+                <Box as="button" ref={triggerRef} onClick={handleGoToCallRoom}>
+                  <Box direction="Row" alignItems="Center" gap="200">
+                    {isConnected ? (
+                      <Icon
+                        size="300"
+                        src={Icons.VolumeHigh}
+                        style={{ color: color.Success.Main }}
+                      />
+                    ) : (
+                      <Spinner size="300" variant="Secondary" />
+                    )}
+
+                    <Text
+                      as="span"
+                      size="L400"
+                      style={{
+                        color: isConnected ? color.Success.Main : color.Warning.Main,
+                      }}
+                    >
+                      {isConnected ? 'Connected' : 'Connecting'}
+                    </Text>
+                  </Box>
+                </Box>
               )}
             </TooltipProvider>
-          )}
+            <TooltipProvider
+              position="Top"
+              offset={4}
+              tooltip={
+                <Tooltip>
+                  <Text>Hang Up</Text>
+                </Tooltip>
+              }
+            >
+              {(triggerRef) => (
+                <IconButton fill="None" size="300" ref={triggerRef} onClick={hangUp}>
+                  <Icon src={Icons.PhoneDown} />
+                </IconButton>
+              )}
+            </TooltipProvider>
+          </Chip>
         </Box>
-        {hasActiveCall && (
-          <TooltipProvider
-            position="Top"
-            offset={4}
-            tooltip={
-              <Tooltip>
-                <Text>Hang Up</Text>
-              </Tooltip>
-            }
-          >
-            {(triggerRef) => (
-              <IconButton fill="None" size="300" ref={triggerRef} onClick={hangUp}>
-                <Icon src={Icons.PhoneDown} />
-              </IconButton>
-            )}
-          </TooltipProvider>
-        )}
+      </Box>
+      <Box className={css.VoiceControls} direction="Row" alignItems="Center" gap="100">
         <TooltipProvider
           position="Top"
           offset={4}

--- a/src/app/pages/client/call/CallProvider.tsx
+++ b/src/app/pages/client/call/CallProvider.tsx
@@ -160,33 +160,39 @@ export function CallProvider({ children }: CallProviderProps) {
     [activeClientWidgetApi, activeCallRoomId, activeClientWidgetApiRoomId]
   );
 
-  const setMic = useCallback(async (newState: boolean) => {
-    if (newState == isMicEnabled) return;
-    setIsMicEnabledState(newState);
-    // If user is deafened and user is unmuting the mic, undeafen
-    if (newState && !isAudioEnabled) setAudio(true);
+  const setMic = useCallback(
+    async (newState: boolean) => {
+      if (newState == isMicEnabled) return;
+      setIsMicEnabledState(newState);
+      // If user is deafened and user is unmuting the mic, undeafen
+      if (newState && !isAudioEnabled) setAudio(true);
 
-    if (isActiveCallReady) {
-      try {
-        await sendWidgetAction(WIDGET_MEDIA_STATE_UPDATE_ACTION, {
-          audio_enabled: newState,
-          video_enabled: isVideoEnabled,
-        });
-      } catch (error) {
-        setIsMicEnabledState(!newState);
-        setAudio(!newState);
-        throw error;
+      if (isActiveCallReady) {
+        try {
+          await sendWidgetAction(WIDGET_MEDIA_STATE_UPDATE_ACTION, {
+            audio_enabled: newState,
+            video_enabled: isVideoEnabled,
+          });
+        } catch (error) {
+          setIsMicEnabledState(!newState);
+          setAudio(!newState);
+          throw error;
+        }
       }
-    }
-  }, [isMicEnabled, isAudioEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
+    },
+    [isMicEnabled, isAudioEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]
+  );
 
-  const setAudio = useCallback(async (newState: boolean) => {
-    if (newState == isAudioEnabled) return;
-    setIsAudioEnabledState(newState);
-    
-    // If mic is unmuted and user is deafening, mute mic
-    if (!newState && isMicEnabled) setMic(false);
-  }, [isAudioEnabled, isMicEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
+  const setAudio = useCallback(
+    async (newState: boolean) => {
+      if (newState == isAudioEnabled) return;
+      setIsAudioEnabledState(newState);
+
+      // If mic is unmuted and user is deafening, mute mic
+      if (!newState && isMicEnabled) setMic(false);
+    },
+    [isAudioEnabled, isMicEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]
+  );
 
   const toggleMic = useCallback(async () => {
     const newState = !isMicEnabled;
@@ -228,10 +234,13 @@ export function CallProvider({ children }: CallProviderProps) {
       return;
     }
 
-    // Deafen
-    const iframeDoc = activeClientWidgetIframeRef?.contentDocument || activeClientWidgetIframeRef?.contentWindow?.document;
+    const iframeDoc =
+      activeClientWidgetIframeRef?.contentDocument ||
+      activeClientWidgetIframeRef?.contentWindow?.document;
+
+    // Loop over all audio elements of the call iframe and set muted according to the isAudioEnabled (deafened) state
     iframeDoc?.querySelectorAll('audio').forEach((el) => {
-      (el as HTMLAudioElement).volume = isAudioEnabled ? 1 : 0;
+      (el as HTMLAudioElement).muted = !isAudioEnabled;
     });
 
     const handleHangup = (ev: CustomEvent) => {

--- a/src/app/pages/client/call/CallProvider.tsx
+++ b/src/app/pages/client/call/CallProvider.tsx
@@ -19,7 +19,7 @@ import { is } from 'immer/dist/internal';
 
 interface MediaStatePayload {
   data?: {
-    mic_enabled?: boolean;
+    audio_enabled?: boolean;
     video_enabled?: boolean;
   };
 }
@@ -255,7 +255,7 @@ export function CallProvider({ children }: CallProviderProps) {
       ev.preventDefault();
 
       /* eslint-disable camelcase */
-      const { mic_enabled: audio_enabled, video_enabled } = ev.detail.data ?? {};
+      const { audio_enabled, video_enabled } = ev.detail.data ?? {};
 
       if (typeof audio_enabled === 'boolean' && audio_enabled !== isMicEnabled) {
         setIsMicEnabledState(audio_enabled);

--- a/src/app/pages/client/call/CallProvider.tsx
+++ b/src/app/pages/client/call/CallProvider.tsx
@@ -48,13 +48,13 @@ interface CallContextState {
     action: WidgetApiToWidgetAction | string,
     data: T
   ) => Promise<void>;
-  isMicEnabled: boolean;
   isAudioEnabled: boolean;
+  isDeafened: boolean;
   isVideoEnabled: boolean;
   isChatOpen: boolean;
   isActiveCallReady: boolean;
-  toggleMic: () => Promise<void>;
   toggleAudio: () => Promise<void>;
+  toggleDeafened: () => Promise<void>;
   toggleVideo: () => Promise<void>;
   toggleChat: () => Promise<void>;
 }
@@ -65,8 +65,8 @@ interface CallProviderProps {
   children: ReactNode;
 }
 
-const DEFAULT_MIC_ENABLED = true;
 const DEFAULT_AUDIO_ENABLED = true;
+const DEFAULT_DEAFENED = false;
 const DEFAULT_VIDEO_ENABLED = false;
 const DEFAULT_CHAT_OPENED = false;
 
@@ -84,8 +84,8 @@ export function CallProvider({ children }: CallProviderProps) {
   const [activeClientWidgetIframeRef, setActiveClientWidgetIframeRef] =
     useState<HTMLIFrameElement | null>(null);
 
-  const [isMicEnabled, setIsMicEnabledState] = useState<boolean>(DEFAULT_MIC_ENABLED);
   const [isAudioEnabled, setIsAudioEnabledState] = useState<boolean>(DEFAULT_AUDIO_ENABLED);
+  const [isDeafened, setIsDeafenedState] = useState<boolean>(DEFAULT_DEAFENED);
   const [isVideoEnabled, setIsVideoEnabledState] = useState<boolean>(DEFAULT_VIDEO_ENABLED);
   const [isChatOpen, setIsChatOpenState] = useState<boolean>(DEFAULT_CHAT_OPENED);
   const [isActiveCallReady, setIsActiveCallReady] = useState<boolean>(false);
@@ -160,12 +160,12 @@ export function CallProvider({ children }: CallProviderProps) {
     [activeClientWidgetApi, activeCallRoomId, activeClientWidgetApiRoomId]
   );
 
-  const setMic = useCallback(
+  const setAudio = useCallback(
     async (newState: boolean) => {
-      if (newState == isMicEnabled) return;
-      setIsMicEnabledState(newState);
+      if (newState == isAudioEnabled) return;
+      setIsAudioEnabledState(newState);
       // If user is deafened and user is unmuting the mic, undeafen
-      if (newState && !isAudioEnabled) setAudio(true);
+      if (newState && isDeafened) setDeafened(false);
 
       if (isActiveCallReady) {
         try {
@@ -174,35 +174,34 @@ export function CallProvider({ children }: CallProviderProps) {
             video_enabled: isVideoEnabled,
           });
         } catch (error) {
-          setIsMicEnabledState(!newState);
-          setAudio(!newState);
+          setIsAudioEnabledState(!newState);
           throw error;
         }
       }
     },
-    [isMicEnabled, isAudioEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]
+    [isAudioEnabled, isDeafened, isVideoEnabled, sendWidgetAction, isActiveCallReady]
   );
 
-  const setAudio = useCallback(
+  const setDeafened = useCallback(
     async (newState: boolean) => {
-      if (newState == isAudioEnabled) return;
-      setIsAudioEnabledState(newState);
+      if (newState == isDeafened) return;
+      setIsDeafenedState(newState);
 
       // If mic is unmuted and user is deafening, mute mic
-      if (!newState && isMicEnabled) setMic(false);
+      if (newState && isAudioEnabled) setAudio(false);
     },
-    [isAudioEnabled, isMicEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]
+    [isDeafened, isAudioEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]
   );
-
-  const toggleMic = useCallback(async () => {
-    const newState = !isMicEnabled;
-    setMic(newState);
-  }, [isMicEnabled, isAudioEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
 
   const toggleAudio = useCallback(async () => {
     const newState = !isAudioEnabled;
     setAudio(newState);
-  }, [isAudioEnabled, isMicEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
+  }, [isAudioEnabled, isDeafened, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
+
+  const toggleDeafened = useCallback(async () => {
+    const newState = !isDeafened;
+    setDeafened(newState);
+  }, [isDeafened, isAudioEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
 
   const toggleVideo = useCallback(async () => {
     const newState = !isVideoEnabled;
@@ -211,7 +210,7 @@ export function CallProvider({ children }: CallProviderProps) {
     if (isActiveCallReady) {
       try {
         await sendWidgetAction(WIDGET_MEDIA_STATE_UPDATE_ACTION, {
-          audio_enabled: isMicEnabled,
+          audio_enabled: isAudioEnabled,
           video_enabled: newState,
         });
       } catch (error) {
@@ -219,7 +218,7 @@ export function CallProvider({ children }: CallProviderProps) {
         throw error;
       }
     }
-  }, [isVideoEnabled, isMicEnabled, isAudioEnabled, sendWidgetAction, isActiveCallReady]);
+  }, [isVideoEnabled, isAudioEnabled, isDeafened, sendWidgetAction, isActiveCallReady]);
 
   useEffect(() => {
     if (!activeCallRoomId && !viewedCallRoomId) {
@@ -238,9 +237,9 @@ export function CallProvider({ children }: CallProviderProps) {
       activeClientWidgetIframeRef?.contentDocument ||
       activeClientWidgetIframeRef?.contentWindow?.document;
 
-    // Loop over all audio elements of the call iframe and set muted according to the isAudioEnabled (deafened) state
+    // Loop over all audio elements of the call iframe and set muted according to the isDeafened state
     iframeDoc?.querySelectorAll('audio').forEach((el) => {
-      (el as HTMLAudioElement).muted = !isAudioEnabled;
+      (el as HTMLAudioElement).muted = isDeafened;
     });
 
     const handleHangup = (ev: CustomEvent) => {
@@ -257,8 +256,8 @@ export function CallProvider({ children }: CallProviderProps) {
       /* eslint-disable camelcase */
       const { audio_enabled, video_enabled } = ev.detail.data ?? {};
 
-      if (typeof audio_enabled === 'boolean' && audio_enabled !== isMicEnabled) {
-        setIsMicEnabledState(audio_enabled);
+      if (typeof audio_enabled === 'boolean' && audio_enabled !== isAudioEnabled) {
+        setIsAudioEnabledState(audio_enabled);
       }
       if (typeof video_enabled === 'boolean' && video_enabled !== isVideoEnabled) {
         setIsVideoEnabledState(video_enabled);
@@ -303,7 +302,7 @@ export function CallProvider({ children }: CallProviderProps) {
     };
 
     void sendWidgetAction(WIDGET_MEDIA_STATE_UPDATE_ACTION, {
-      audio_enabled: isMicEnabled,
+      audio_enabled: isAudioEnabled,
       video_enabled: isVideoEnabled,
     }).catch(() => {
       // Widget transport may reject while call/session setup is still in progress.
@@ -321,8 +320,8 @@ export function CallProvider({ children }: CallProviderProps) {
     activeClientWidgetApiRoomId,
     hangUp,
     isChatOpen,
-    isMicEnabled,
     isAudioEnabled,
+    isDeafened,
     isVideoEnabled,
     isActiveCallReady,
     viewedRoomId,
@@ -350,12 +349,12 @@ export function CallProvider({ children }: CallProviderProps) {
       activeClientWidget,
       sendWidgetAction,
       isChatOpen,
-      isMicEnabled,
       isAudioEnabled,
+      isDeafened,
       isVideoEnabled,
       isActiveCallReady,
-      toggleMic,
       toggleAudio,
+      toggleDeafened,
       toggleVideo,
       toggleChat,
     }),
@@ -373,7 +372,7 @@ export function CallProvider({ children }: CallProviderProps) {
       isAudioEnabled,
       isVideoEnabled,
       isActiveCallReady,
-      toggleMic,
+      toggleAudio,
       toggleVideo,
       toggleChat,
     ]

--- a/src/app/pages/client/call/CallProvider.tsx
+++ b/src/app/pages/client/call/CallProvider.tsx
@@ -15,10 +15,11 @@ import {
 } from 'matrix-widget-api';
 import { useParams } from 'react-router-dom';
 import { SmallWidget } from '../../../features/call/SmallWidget';
+import { is } from 'immer/dist/internal';
 
 interface MediaStatePayload {
   data?: {
-    audio_enabled?: boolean;
+    mic_enabled?: boolean;
     video_enabled?: boolean;
   };
 }
@@ -47,10 +48,12 @@ interface CallContextState {
     action: WidgetApiToWidgetAction | string,
     data: T
   ) => Promise<void>;
+  isMicEnabled: boolean;
   isAudioEnabled: boolean;
   isVideoEnabled: boolean;
   isChatOpen: boolean;
   isActiveCallReady: boolean;
+  toggleMic: () => Promise<void>;
   toggleAudio: () => Promise<void>;
   toggleVideo: () => Promise<void>;
   toggleChat: () => Promise<void>;
@@ -62,6 +65,7 @@ interface CallProviderProps {
   children: ReactNode;
 }
 
+const DEFAULT_MIC_ENABLED = true;
 const DEFAULT_AUDIO_ENABLED = true;
 const DEFAULT_VIDEO_ENABLED = false;
 const DEFAULT_CHAT_OPENED = false;
@@ -80,6 +84,7 @@ export function CallProvider({ children }: CallProviderProps) {
   const [activeClientWidgetIframeRef, setActiveClientWidgetIframeRef] =
     useState<HTMLIFrameElement | null>(null);
 
+  const [isMicEnabled, setIsMicEnabledState] = useState<boolean>(DEFAULT_MIC_ENABLED);
   const [isAudioEnabled, setIsAudioEnabledState] = useState<boolean>(DEFAULT_AUDIO_ENABLED);
   const [isVideoEnabled, setIsVideoEnabledState] = useState<boolean>(DEFAULT_VIDEO_ENABLED);
   const [isChatOpen, setIsChatOpenState] = useState<boolean>(DEFAULT_CHAT_OPENED);
@@ -155,9 +160,11 @@ export function CallProvider({ children }: CallProviderProps) {
     [activeClientWidgetApi, activeCallRoomId, activeClientWidgetApiRoomId]
   );
 
-  const toggleAudio = useCallback(async () => {
-    const newState = !isAudioEnabled;
-    setIsAudioEnabledState(newState);
+  const setMic = useCallback(async (newState: boolean) => {
+    if (newState == isMicEnabled) return;
+    setIsMicEnabledState(newState);
+    // If user is deafened and user is unmuting the mic, undeafen
+    if (newState && !isAudioEnabled) setAudio(true);
 
     if (isActiveCallReady) {
       try {
@@ -166,11 +173,30 @@ export function CallProvider({ children }: CallProviderProps) {
           video_enabled: isVideoEnabled,
         });
       } catch (error) {
-        setIsAudioEnabledState(!newState);
+        setIsMicEnabledState(!newState);
+        setAudio(!newState);
         throw error;
       }
     }
-  }, [isAudioEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
+  }, [isMicEnabled, isAudioEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
+
+  const setAudio = useCallback(async (newState: boolean) => {
+    if (newState == isAudioEnabled) return;
+    setIsAudioEnabledState(newState);
+    
+    // If mic is unmuted and user is deafening, mute mic
+    if (!newState && isMicEnabled) setMic(false);
+  }, [isAudioEnabled, isMicEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
+
+  const toggleMic = useCallback(async () => {
+    const newState = !isMicEnabled;
+    setMic(newState);
+  }, [isMicEnabled, isAudioEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
+
+  const toggleAudio = useCallback(async () => {
+    const newState = !isAudioEnabled;
+    setAudio(newState);
+  }, [isAudioEnabled, isMicEnabled, isVideoEnabled, sendWidgetAction, isActiveCallReady]);
 
   const toggleVideo = useCallback(async () => {
     const newState = !isVideoEnabled;
@@ -179,7 +205,7 @@ export function CallProvider({ children }: CallProviderProps) {
     if (isActiveCallReady) {
       try {
         await sendWidgetAction(WIDGET_MEDIA_STATE_UPDATE_ACTION, {
-          audio_enabled: isAudioEnabled,
+          audio_enabled: isMicEnabled,
           video_enabled: newState,
         });
       } catch (error) {
@@ -187,7 +213,7 @@ export function CallProvider({ children }: CallProviderProps) {
         throw error;
       }
     }
-  }, [isVideoEnabled, isAudioEnabled, sendWidgetAction, isActiveCallReady]);
+  }, [isVideoEnabled, isMicEnabled, isAudioEnabled, sendWidgetAction, isActiveCallReady]);
 
   useEffect(() => {
     if (!activeCallRoomId && !viewedCallRoomId) {
@@ -197,6 +223,16 @@ export function CallProvider({ children }: CallProviderProps) {
     if (!activeClientWidgetApi) {
       return;
     }
+
+    if (!activeClientWidgetIframeRef) {
+      return;
+    }
+
+    // Deafen
+    const iframeDoc = activeClientWidgetIframeRef?.contentDocument || activeClientWidgetIframeRef?.contentWindow?.document;
+    iframeDoc?.querySelectorAll('audio').forEach((el) => {
+      (el as HTMLAudioElement).volume = isAudioEnabled ? 1 : 0;
+    });
 
     const handleHangup = (ev: CustomEvent) => {
       ev.preventDefault();
@@ -210,10 +246,10 @@ export function CallProvider({ children }: CallProviderProps) {
       ev.preventDefault();
 
       /* eslint-disable camelcase */
-      const { audio_enabled, video_enabled } = ev.detail.data ?? {};
+      const { mic_enabled: audio_enabled, video_enabled } = ev.detail.data ?? {};
 
-      if (typeof audio_enabled === 'boolean' && audio_enabled !== isAudioEnabled) {
-        setIsAudioEnabledState(audio_enabled);
+      if (typeof audio_enabled === 'boolean' && audio_enabled !== isMicEnabled) {
+        setIsMicEnabledState(audio_enabled);
       }
       if (typeof video_enabled === 'boolean' && video_enabled !== isVideoEnabled) {
         setIsVideoEnabledState(video_enabled);
@@ -258,7 +294,7 @@ export function CallProvider({ children }: CallProviderProps) {
     };
 
     void sendWidgetAction(WIDGET_MEDIA_STATE_UPDATE_ACTION, {
-      audio_enabled: isAudioEnabled,
+      audio_enabled: isMicEnabled,
       video_enabled: isVideoEnabled,
     }).catch(() => {
       // Widget transport may reject while call/session setup is still in progress.
@@ -276,6 +312,7 @@ export function CallProvider({ children }: CallProviderProps) {
     activeClientWidgetApiRoomId,
     hangUp,
     isChatOpen,
+    isMicEnabled,
     isAudioEnabled,
     isVideoEnabled,
     isActiveCallReady,
@@ -304,9 +341,11 @@ export function CallProvider({ children }: CallProviderProps) {
       activeClientWidget,
       sendWidgetAction,
       isChatOpen,
+      isMicEnabled,
       isAudioEnabled,
       isVideoEnabled,
       isActiveCallReady,
+      toggleMic,
       toggleAudio,
       toggleVideo,
       toggleChat,
@@ -325,7 +364,7 @@ export function CallProvider({ children }: CallProviderProps) {
       isAudioEnabled,
       isVideoEnabled,
       isActiveCallReady,
-      toggleAudio,
+      toggleMic,
       toggleVideo,
       toggleChat,
     ]


### PR DESCRIPTION
### Description
Adds the deafen functionality to voice calls. This is achieved by iterating over all audio elements in the call iframe and muting them based on if the user is deafened or not. When a user deafens, they will also be muted. If the user unmutes when deafened, they will also be undeafened. 
Because the voice control UI could not fit the new deafen icon well, it has been restructured to have the connecting status appear above the controls when the user joins a call.
I am also of course willing to make any changes needed.

Fixes #

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
