### PR TITLE
feat: add the ability to reply with any filetype

### DIFF
--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -9,7 +9,7 @@ import React, {
 } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 import { isKeyHotkey } from 'is-hotkey';
-import { EventType, IContent, MsgType, RelationType, Room } from 'matrix-js-sdk';
+import { EventType, IContent, IEventRelation, MsgType, RelationType, Room } from 'matrix-js-sdk';
 import { ReactEditor } from 'slate-react';
 import { Transforms, Editor } from 'slate';
 import {
@@ -68,6 +68,7 @@ import { useFilePicker } from '../../hooks/useFilePicker';
 import { useFilePasteHandler } from '../../hooks/useFilePasteHandler';
 import { useFileDropZone } from '../../hooks/useFileDrop';
 import {
+  IReplyDraft,
   TUploadItem,
   TUploadMetadata,
   roomIdToMsgDraftAtomFamily,
@@ -276,22 +277,26 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     };
 
     const handleSendUpload = async (uploads: UploadSuccess[]) => {
-      const contentsPromises = uploads.map(async (upload) => {
-        const replyDraftCont = replyDraft;
-        setReplyDraft(undefined);
+      const plaintext = toPlainText(editor.children, isMarkdown).trim();
+      const replyDraftBase = plaintext.length === 0 ? replyDraft : undefined;
+      setReplyDraft(undefined);
+
+      const contentsPromises = uploads.map(async (upload, index) => {
+        const replyDraftContent = index === 0 ? replyDraftBase : undefined;
+
         const fileItem = selectedFiles.find((f) => f.file === upload.file);
         if (!fileItem) throw new Error('Broken upload');
 
         if (fileItem.file.type.startsWith('image')) {
-          return getImageMsgContent(mx, fileItem, upload.mxc, replyDraftCont);
+          return getImageMsgContent(mx, fileItem, upload.mxc, replyDraftContent);
         }
         if (fileItem.file.type.startsWith('video')) {
-          return getVideoMsgContent(mx, fileItem, upload.mxc, replyDraftCont);
+          return getVideoMsgContent(mx, fileItem, upload.mxc, replyDraftContent);
         }
         if (fileItem.file.type.startsWith('audio')) {
-          return getAudioMsgContent(fileItem, upload.mxc, replyDraftCont);
+          return getAudioMsgContent(fileItem, upload.mxc, replyDraftContent);
         }
-        return getFileMsgContent(fileItem, upload.mxc, replyDraftCont);
+        return getFileMsgContent(fileItem, upload.mxc, replyDraftContent);
       });
       handleCancelUpload(uploads);
       const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -119,6 +119,23 @@ import { useRoomCreatorsTag } from '../../hooks/useRoomCreatorsTag';
 import { usePowerLevelTags } from '../../hooks/usePowerLevelTags';
 import { useComposingCheck } from '../../hooks/useComposingCheck';
 
+const getReplyContent = (replyDraft: IReplyDraft | undefined): IEventRelation => {
+  if (!replyDraft) return {};
+
+  const relatesTo: IEventRelation = {};
+
+  relatesTo['m.in_reply_to'] = {
+    event_id: replyDraft.eventId,
+  };
+
+  if (replyDraft.relation?.rel_type === RelationType.Thread) {
+    relatesTo.event_id = replyDraft.relation.event_id;
+    relatesTo.rel_type = RelationType.Thread;
+    relatesTo.is_falling_back = false;
+  }
+  return relatesTo;
+};
+
 interface RoomInputProps {
   editor: Editor;
   fileDropContainerRef: RefObject<HTMLElement>;
@@ -277,29 +294,31 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
     };
 
     const handleSendUpload = async (uploads: UploadSuccess[]) => {
-      const plaintext = toPlainText(editor.children, isMarkdown).trim();
-      const replyDraftBase = plaintext.length === 0 ? replyDraft : undefined;
-      setReplyDraft(undefined);
-
-      const contentsPromises = uploads.map(async (upload, index) => {
-        const replyDraftContent = index === 0 ? replyDraftBase : undefined;
-
+      const contentsPromises = uploads.map(async (upload) => {
         const fileItem = selectedFiles.find((f) => f.file === upload.file);
         if (!fileItem) throw new Error('Broken upload');
 
         if (fileItem.file.type.startsWith('image')) {
-          return getImageMsgContent(mx, fileItem, upload.mxc, replyDraftContent);
+          return getImageMsgContent(mx, fileItem, upload.mxc);
         }
         if (fileItem.file.type.startsWith('video')) {
-          return getVideoMsgContent(mx, fileItem, upload.mxc, replyDraftContent);
+          return getVideoMsgContent(mx, fileItem, upload.mxc);
         }
         if (fileItem.file.type.startsWith('audio')) {
-          return getAudioMsgContent(fileItem, upload.mxc, replyDraftContent);
+          return getAudioMsgContent(fileItem, upload.mxc);
         }
-        return getFileMsgContent(fileItem, upload.mxc, replyDraftContent);
+        return getFileMsgContent(fileItem, upload.mxc);
       });
       handleCancelUpload(uploads);
       const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));
+
+      if (contents.length > 0) {
+        const plaintext = toPlainText(editor.children, isMarkdown).trim();
+        const replyContent = plaintext.length === 0 ? getReplyContent(replyDraft) : undefined;
+        if (replyContent) contents[0]['m.relates_to'] = replyContent;
+        setReplyDraft(undefined);
+      }
+
       contents.forEach((content) => mx.sendMessage(roomId, content as any));
     };
 
@@ -367,18 +386,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         content.format = 'org.matrix.custom.html';
         content.formatted_body = formattedBody;
       }
-      if (replyDraft) {
-        content['m.relates_to'] = {
-          'm.in_reply_to': {
-            event_id: replyDraft.eventId,
-          },
-        };
-        if (replyDraft.relation?.rel_type === RelationType.Thread) {
-          content['m.relates_to'].event_id = replyDraft.relation.event_id;
-          content['m.relates_to'].rel_type = RelationType.Thread;
-          content['m.relates_to'].is_falling_back = false;
-        }
-      }
+      if (replyDraft) content['m.relates_to'] = getReplyContent(replyDraft);
       mx.sendMessage(roomId, content as any);
       resetEditor(editor);
       resetEditorHistory(editor);

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -281,7 +281,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         if (!fileItem) throw new Error('Broken upload');
 
         if (fileItem.file.type.startsWith('image')) {
-          return getImageMsgContent(mx, fileItem, upload.mxc);
+          return getImageMsgContent(mx, fileItem, upload.mxc, replyDraft);
         }
         if (fileItem.file.type.startsWith('video')) {
           return getVideoMsgContent(mx, fileItem, upload.mxc);

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -277,19 +277,21 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
 
     const handleSendUpload = async (uploads: UploadSuccess[]) => {
       const contentsPromises = uploads.map(async (upload) => {
+        const replyDraftCont = replyDraft;
+        setReplyDraft(undefined);
         const fileItem = selectedFiles.find((f) => f.file === upload.file);
         if (!fileItem) throw new Error('Broken upload');
 
         if (fileItem.file.type.startsWith('image')) {
-          return getImageMsgContent(mx, fileItem, upload.mxc, replyDraft);
+          return getImageMsgContent(mx, fileItem, upload.mxc, replyDraftCont);
         }
         if (fileItem.file.type.startsWith('video')) {
-          return getVideoMsgContent(mx, fileItem, upload.mxc, replyDraft);
+          return getVideoMsgContent(mx, fileItem, upload.mxc, replyDraftCont);
         }
         if (fileItem.file.type.startsWith('audio')) {
-          return getAudioMsgContent(fileItem, upload.mxc, replyDraft);
+          return getAudioMsgContent(fileItem, upload.mxc, replyDraftCont);
         }
-        return getFileMsgContent(fileItem, upload.mxc, replyDraft);
+        return getFileMsgContent(fileItem, upload.mxc, replyDraftCont);
       });
       handleCancelUpload(uploads);
       const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -284,12 +284,12 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
           return getImageMsgContent(mx, fileItem, upload.mxc, replyDraft);
         }
         if (fileItem.file.type.startsWith('video')) {
-          return getVideoMsgContent(mx, fileItem, upload.mxc);
+          return getVideoMsgContent(mx, fileItem, upload.mxc, replyDraft);
         }
         if (fileItem.file.type.startsWith('audio')) {
-          return getAudioMsgContent(fileItem, upload.mxc);
+          return getAudioMsgContent(fileItem, upload.mxc, replyDraft);
         }
-        return getFileMsgContent(fileItem, upload.mxc);
+        return getFileMsgContent(fileItem, upload.mxc, replyDraft);
       });
       handleCancelUpload(uploads);
       const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -118,6 +118,7 @@ import { useTheme } from '../../hooks/useTheme';
 import { useRoomCreatorsTag } from '../../hooks/useRoomCreatorsTag';
 import { usePowerLevelTags } from '../../hooks/usePowerLevelTags';
 import { useComposingCheck } from '../../hooks/useComposingCheck';
+import { StickerEventContent } from 'matrix-js-sdk/lib/types';
 
 const getReplyContent = (replyDraft: IReplyDraft | undefined): IEventRelation => {
   if (!replyDraft) return {};
@@ -454,11 +455,16 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         await getImageUrlBlob(stickerUrl)
       );
 
-      mx.sendEvent(roomId, EventType.Sticker, {
+      const content: StickerEventContent = {
         body: label,
         url: mxc,
         info,
-      });
+      };
+      if (replyDraft) {
+        content['m.relates_to'] = getReplyContent(replyDraft);
+        setReplyDraft(undefined);
+      }
+      mx.sendEvent(roomId, EventType.Sticker, content);
     };
 
     return (

--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -29,6 +29,7 @@ import {
   toRem,
 } from 'folds';
 
+import { StickerEventContent } from 'matrix-js-sdk/lib/types';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import {
   CustomEditor,
@@ -118,7 +119,6 @@ import { useTheme } from '../../hooks/useTheme';
 import { useRoomCreatorsTag } from '../../hooks/useRoomCreatorsTag';
 import { usePowerLevelTags } from '../../hooks/usePowerLevelTags';
 import { useComposingCheck } from '../../hooks/useComposingCheck';
-import { StickerEventContent } from 'matrix-js-sdk/lib/types';
 
 const getReplyContent = (replyDraft: IReplyDraft | undefined): IEventRelation => {
   if (!replyDraft) return {};
@@ -136,6 +136,9 @@ const getReplyContent = (replyDraft: IReplyDraft | undefined): IEventRelation =>
   }
   return relatesTo;
 };
+interface ReplyEventContent {
+  'm.relates_to'?: IEventRelation;
+}
 
 interface RoomInputProps {
   editor: Editor;
@@ -455,7 +458,7 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         await getImageUrlBlob(stickerUrl)
       );
 
-      const content: StickerEventContent = {
+      const content: StickerEventContent & ReplyEventContent = {
         body: label,
         url: mxc,
         info,

--- a/src/app/features/room/RoomTimeline.tsx
+++ b/src/app/features/room/RoomTimeline.tsx
@@ -1235,6 +1235,7 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
         const reactionRelations = getEventReactions(timelineSet, mEventId);
         const reactions = reactionRelations && reactionRelations.getSortedAnnotationsByKey();
         const hasReactions = reactions && reactions.length > 0;
+        const { replyEventId, threadRootId } = mEvent;
         const highlighted = focusItem?.index === item && focusItem.highlight;
 
         return (
@@ -1257,6 +1258,20 @@ export function RoomTimeline({ room, eventId, roomInputRef, editor }: RoomTimeli
             onUsernameClick={handleUsernameClick}
             onReplyClick={handleReplyClick}
             onReactionToggle={handleReactionToggle}
+            reply={
+              replyEventId && (
+                <Reply
+                  room={room}
+                  timelineSet={timelineSet}
+                  replyEventId={replyEventId}
+                  threadRootId={threadRootId}
+                  onClick={handleOpenReply}
+                  getMemberPowerTag={getMemberPowerTag}
+                  accessibleTagColors={accessiblePowerTagColors}
+                  legacyUsernameColor={legacyUsernameColor || direct}
+                />
+              )
+            }
             reactions={
               reactionRelations && (
                 <Reactions

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -43,7 +43,7 @@ const generateThumbnailContent = async (
   return thumbnailContent;
 };
 
-export const getReplyEvent = (replyDraft: any): any => {
+export const getReplyEvent = (replyDraft: IContent): IEventRelation => {
   const relatesTo: IContent = {};
 
   relatesTo['m.in_reply_to'] = {
@@ -62,7 +62,7 @@ export const getImageMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
   mxc: string,
-  replyDraft?: any
+  replyDraft?: IContent
 ): Promise<IContent> => {
   const { file, originalFile, encInfo, metadata } = item;
   const [imgError, imgEl] = await to(loadImageElement(getImageFileUrl(originalFile)));
@@ -100,7 +100,7 @@ export const getVideoMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
   mxc: string,
-  replyDraft?: any
+  replyDraft?: IContent
 ): Promise<IContent> => {
   const { file, originalFile, encInfo, metadata } = item;
 
@@ -147,7 +147,11 @@ export const getVideoMsgContent = async (
   return content;
 };
 
-export const getAudioMsgContent = (item: TUploadItem, mxc: string, replyDraft?: any): IContent => {
+export const getAudioMsgContent = (
+  item: TUploadItem,
+  mxc: string,
+  replyDraft?: IContent
+): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.Audio,
@@ -170,7 +174,11 @@ export const getAudioMsgContent = (item: TUploadItem, mxc: string, replyDraft?: 
   return content;
 };
 
-export const getFileMsgContent = (item: TUploadItem, mxc: string, replyDraft?: any): IContent => {
+export const getFileMsgContent = (
+  item: TUploadItem,
+  mxc: string,
+  replyDraft?: IContent
+): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.File,

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -1,4 +1,4 @@
-import { IContent, MatrixClient, RelationType, MsgType, IEventRelation } from 'matrix-js-sdk';
+import { IContent, MatrixClient, MsgType } from 'matrix-js-sdk';
 import to from 'await-to-js';
 import {
   IThumbnailContent,
@@ -43,28 +43,10 @@ const generateThumbnailContent = async (
   return thumbnailContent;
 };
 
-export const getReplyEvent = (replyDraft: IContent): IEventRelation => {
-  if (!replyDraft) return {};
-
-  const relatesTo: IEventRelation = {};
-
-  relatesTo['m.in_reply_to'] = {
-    event_id: replyDraft.eventId,
-  };
-
-  if (replyDraft.relation?.rel_type === RelationType.Thread) {
-    relatesTo.event_id = replyDraft.relation.event_id;
-    relatesTo.rel_type = RelationType.Thread;
-    relatesTo.is_falling_back = false;
-  }
-  return relatesTo;
-};
-
 export const getImageMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
-  mxc: string,
-  replyDraft?: IContent
+  mxc: string
 ): Promise<IContent> => {
   const { file, originalFile, encInfo, metadata } = item;
   const [imgError, imgEl] = await to(loadImageElement(getImageFileUrl(originalFile)));
@@ -76,8 +58,6 @@ export const getImageMsgContent = async (
     body: file.name,
     [MATRIX_SPOILER_PROPERTY_NAME]: metadata.markedAsSpoiler,
   };
-
-  if (replyDraft) content['m.relates_to'] = getReplyEvent(replyDraft);
 
   if (imgEl) {
     const blurHash = encodeBlurHash(imgEl, 512, scaleYDimension(imgEl.width, 512, imgEl.height));
@@ -101,8 +81,7 @@ export const getImageMsgContent = async (
 export const getVideoMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
-  mxc: string,
-  replyDraft?: IContent
+  mxc: string
 ): Promise<IContent> => {
   const { file, originalFile, encInfo, metadata } = item;
 
@@ -115,7 +94,6 @@ export const getVideoMsgContent = async (
     body: file.name,
     [MATRIX_SPOILER_PROPERTY_NAME]: metadata.markedAsSpoiler,
   };
-  if (replyDraft) content['m.relates_to'] = getReplyEvent(replyDraft);
   if (videoEl) {
     const [thumbError, thumbContent] = await to(
       generateThumbnailContent(
@@ -149,11 +127,7 @@ export const getVideoMsgContent = async (
   return content;
 };
 
-export const getAudioMsgContent = (
-  item: TUploadItem,
-  mxc: string,
-  replyDraft?: IContent
-): IContent => {
+export const getAudioMsgContent = (item: TUploadItem, mxc: string): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.Audio,
@@ -164,7 +138,6 @@ export const getAudioMsgContent = (
       size: file.size,
     },
   };
-  if (replyDraft) content['m.relates_to'] = getReplyEvent(replyDraft);
   if (encInfo) {
     content.file = {
       ...encInfo,
@@ -176,11 +149,7 @@ export const getAudioMsgContent = (
   return content;
 };
 
-export const getFileMsgContent = (
-  item: TUploadItem,
-  mxc: string,
-  replyDraft?: IContent
-): IContent => {
+export const getFileMsgContent = (item: TUploadItem, mxc: string): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.File,
@@ -191,7 +160,6 @@ export const getFileMsgContent = (
       size: file.size,
     },
   };
-  if (replyDraft) content['m.relates_to'] = getReplyEvent(replyDraft);
   if (encInfo) {
     content.file = {
       ...encInfo,

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -1,4 +1,4 @@
-import { IContent, MatrixClient, MsgType } from 'matrix-js-sdk';
+import { IContent, MatrixClient, RelationType, MsgType } from 'matrix-js-sdk';
 import to from 'await-to-js';
 import {
   IThumbnailContent,
@@ -46,7 +46,8 @@ const generateThumbnailContent = async (
 export const getImageMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
-  mxc: string
+  mxc: string,
+  replyDraft?: any
 ): Promise<IContent> => {
   const { file, originalFile, encInfo, metadata } = item;
   const [imgError, imgEl] = await to(loadImageElement(getImageFileUrl(originalFile)));
@@ -58,6 +59,19 @@ export const getImageMsgContent = async (
     body: file.name,
     [MATRIX_SPOILER_PROPERTY_NAME]: metadata.markedAsSpoiler,
   };
+
+  if (replyDraft) {
+    content['m.relates_to'] = {
+      'm.in_reply_to': {
+        event_id: replyDraft.eventId,
+      },
+    };
+    if (replyDraft.relation?.rel_type === RelationType.Thread) {
+      content['m.relates_to'].event_id = replyDraft.relation.event_id;
+      content['m.relates_to'].rel_type = RelationType.Thread;
+      content['m.relates_to'].is_falling_back = false;
+    }
+  }
   if (imgEl) {
     const blurHash = encodeBlurHash(imgEl, 512, scaleYDimension(imgEl.width, 512, imgEl.height));
 

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -58,7 +58,6 @@ export const getImageMsgContent = async (
     body: file.name,
     [MATRIX_SPOILER_PROPERTY_NAME]: metadata.markedAsSpoiler,
   };
-
   if (imgEl) {
     const blurHash = encodeBlurHash(imgEl, 512, scaleYDimension(imgEl.width, 512, imgEl.height));
 

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -43,6 +43,21 @@ const generateThumbnailContent = async (
   return thumbnailContent;
 };
 
+export const getReplyEvent = (replyDraft: any): any => {
+  const relatesTo: IContent = {};
+
+  relatesTo['m.in_reply_to'] = {
+    event_id: replyDraft.eventId,
+  };
+
+  if (replyDraft.relation?.rel_type === RelationType.Thread) {
+    relatesTo.event_id = replyDraft.relation.event_id;
+    relatesTo.rel_type = RelationType.Thread;
+    relatesTo.is_falling_back = false;
+  }
+  return relatesTo;
+};
+
 export const getImageMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
@@ -60,18 +75,8 @@ export const getImageMsgContent = async (
     [MATRIX_SPOILER_PROPERTY_NAME]: metadata.markedAsSpoiler,
   };
 
-  if (replyDraft) {
-    content['m.relates_to'] = {
-      'm.in_reply_to': {
-        event_id: replyDraft.eventId,
-      },
-    };
-    if (replyDraft.relation?.rel_type === RelationType.Thread) {
-      content['m.relates_to'].event_id = replyDraft.relation.event_id;
-      content['m.relates_to'].rel_type = RelationType.Thread;
-      content['m.relates_to'].is_falling_back = false;
-    }
-  }
+  if (replyDraft) content['m.relates_to'] = getReplyEvent(replyDraft);
+
   if (imgEl) {
     const blurHash = encodeBlurHash(imgEl, 512, scaleYDimension(imgEl.width, 512, imgEl.height));
 
@@ -94,7 +99,8 @@ export const getImageMsgContent = async (
 export const getVideoMsgContent = async (
   mx: MatrixClient,
   item: TUploadItem,
-  mxc: string
+  mxc: string,
+  replyDraft?: any
 ): Promise<IContent> => {
   const { file, originalFile, encInfo, metadata } = item;
 
@@ -107,6 +113,7 @@ export const getVideoMsgContent = async (
     body: file.name,
     [MATRIX_SPOILER_PROPERTY_NAME]: metadata.markedAsSpoiler,
   };
+  if (replyDraft) content['m.relates_to'] = getReplyEvent(replyDraft);
   if (videoEl) {
     const [thumbError, thumbContent] = await to(
       generateThumbnailContent(
@@ -140,7 +147,7 @@ export const getVideoMsgContent = async (
   return content;
 };
 
-export const getAudioMsgContent = (item: TUploadItem, mxc: string): IContent => {
+export const getAudioMsgContent = (item: TUploadItem, mxc: string, replyDraft?: any): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.Audio,
@@ -151,6 +158,7 @@ export const getAudioMsgContent = (item: TUploadItem, mxc: string): IContent => 
       size: file.size,
     },
   };
+  if (replyDraft) content['m.relates_to'] = getReplyEvent(replyDraft);
   if (encInfo) {
     content.file = {
       ...encInfo,
@@ -162,7 +170,7 @@ export const getAudioMsgContent = (item: TUploadItem, mxc: string): IContent => 
   return content;
 };
 
-export const getFileMsgContent = (item: TUploadItem, mxc: string): IContent => {
+export const getFileMsgContent = (item: TUploadItem, mxc: string, replyDraft?: any): IContent => {
   const { file, encInfo } = item;
   const content: IContent = {
     msgtype: MsgType.File,
@@ -173,6 +181,7 @@ export const getFileMsgContent = (item: TUploadItem, mxc: string): IContent => {
       size: file.size,
     },
   };
+  if (replyDraft) content['m.relates_to'] = getReplyEvent(replyDraft);
   if (encInfo) {
     content.file = {
       ...encInfo,

--- a/src/app/features/room/msgContent.ts
+++ b/src/app/features/room/msgContent.ts
@@ -1,4 +1,4 @@
-import { IContent, MatrixClient, RelationType, MsgType } from 'matrix-js-sdk';
+import { IContent, MatrixClient, RelationType, MsgType, IEventRelation } from 'matrix-js-sdk';
 import to from 'await-to-js';
 import {
   IThumbnailContent,
@@ -44,7 +44,9 @@ const generateThumbnailContent = async (
 };
 
 export const getReplyEvent = (replyDraft: IContent): IEventRelation => {
-  const relatesTo: IContent = {};
+  if (!replyDraft) return {};
+
+  const relatesTo: IEventRelation = {};
 
   relatesTo['m.in_reply_to'] = {
     event_id: replyDraft.eventId,


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Whenever I talk with people and they ask me to send them a file or i want to reply with an image to something they say I currently have to reply with an empty message and then the image/file. 

This fix would allow anyone to reply with any file or a sticker to an event.

Also while you can send multiple files in one burst or a file and text, only the topmost item gets the reply event so it doesn't show as many reply icon visuals as there are events, with the reply working as before for text+file, with only the text having the reply tag as it is always the topmost item.

Additionally the older flow where you couldn't reply with images/files has confused all of the people that i have on-boarded or that were new to the platform

Example of how this feature could be used
<img width="978" height="841" alt="image" src="https://github.com/user-attachments/assets/11f32d09-b1eb-4e66-9758-efdd848a5d53" />

Fixes #2659 

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
