### PR TITLE
fix: reply properly when attachments are present

### DIFF
--- a/src/app/features/room/RoomInput.tsx
+++ b/src/app/features/room/RoomInput.tsx
@@ -292,7 +292,21 @@ export const RoomInput = forwardRef<HTMLDivElement, RoomInputProps>(
         return getFileMsgContent(fileItem, upload.mxc);
       });
       handleCancelUpload(uploads);
-      const contents = fulfilledPromiseSettledResult(await Promise.allSettled(contentsPromises));
+      let contents = fulfilledPromiseSettledResult(
+        await Promise.allSettled(contentsPromises)
+      ) as any as IContent[];
+
+      if (replyDraft) {
+        contents = contents.map((o) => ({
+          ...o,
+          'm.relates_to': {
+            'm.in_reply_to': {
+              event_id: replyDraft.eventId,
+            },
+          },
+        }));
+        setReplyDraft(undefined);
+      }
       contents.forEach((content) => mx.sendMessage(roomId, content as any));
     };
 


### PR DESCRIPTION
### Description
When a reply is in queue and the user sends an attachment, mark the new message as a reply. 

I also noticed that captions aren't used (like for example in Element X), but I presume that is the case in order for bulk uploading to be cleaner. Hence I didn't mess with that at all.

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
