### PR TITLE
feat: show precise time on hovering the time of a message

### DIFF
--- a/src/app/components/message/Time.tsx
+++ b/src/app/components/message/Time.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps } from 'react';
-import { Text, as } from 'folds';
+import { Text, as, Tooltip, TooltipProvider, toRem } from 'folds';
 import {
   timeDayMonYear,
   timeHourMinute,
@@ -42,23 +42,34 @@ export const Time = as<'span', TimeProps & ComponentProps<typeof Text>>(
       time = `${timeDayMonYear(ts, dateFormatString)} ${formattedTime}`;
     }
 
-    const timeTitle = `Sent ${timeDayMonYear(ts, dateFormatString)}, at ${timeHourMinuteSecond(
-      ts,
-      hour24Clock
-    )}`;
-
     return (
-      <Text
-        as="time"
-        style={{ flexShrink: 0 }}
-        size="T200"
-        priority="300"
-        {...props}
-        title={timeTitle}
-        ref={ref}
+      <TooltipProvider
+        delay={400}
+        position="Top"
+        style={{ textAlign: 'center' }}
+        tooltip={
+          <Tooltip>
+            <Text size="H5">
+              {timeDayMonYear(ts, dateFormatString)}
+              <br />
+              {timeHourMinuteSecond(ts, hour24Clock)}
+            </Text>
+          </Tooltip>
+        }
       >
-        {time}
-      </Text>
+        {(triggerRef) => (
+          <Text
+            as="time"
+            style={{ flexShrink: 0 }}
+            size="T200"
+            priority="300"
+            {...props}
+            ref={triggerRef}
+          >
+            {time}
+          </Text>
+        )}
+      </TooltipProvider>
     );
   }
 );

--- a/src/app/components/message/Time.tsx
+++ b/src/app/components/message/Time.tsx
@@ -1,6 +1,12 @@
 import React, { ComponentProps } from 'react';
 import { Text, as } from 'folds';
-import { timeDayMonYear, timeHourMinute, today, yesterday } from '../../utils/time';
+import {
+  timeDayMonYear,
+  timeHourMinute,
+  timeHourMinuteSecond,
+  today,
+  yesterday,
+} from '../../utils/time';
 
 export type TimeProps = {
   compact?: boolean;
@@ -36,8 +42,21 @@ export const Time = as<'span', TimeProps & ComponentProps<typeof Text>>(
       time = `${timeDayMonYear(ts, dateFormatString)} ${formattedTime}`;
     }
 
+    const timeTitle = `Sent ${timeDayMonYear(ts, dateFormatString)}, at ${timeHourMinuteSecond(
+      ts,
+      hour24Clock
+    )}`;
+
     return (
-      <Text as="time" style={{ flexShrink: 0 }} size="T200" priority="300" {...props} ref={ref}>
+      <Text
+        as="time"
+        style={{ flexShrink: 0 }}
+        size="T200"
+        priority="300"
+        {...props}
+        title={timeTitle}
+        ref={ref}
+      >
         {time}
       </Text>
     );

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -21,6 +21,9 @@ export const timeYear = (ts: number): string => dayjs(ts).format('YYYY');
 export const timeHourMinute = (ts: number, hour24Clock: boolean): string =>
   dayjs(ts).format(hour24Clock ? 'HH:mm' : 'hh:mm A');
 
+export const timeHourMinuteSecond = (ts: number, hour24Clock: boolean): string =>
+  dayjs(ts).format(hour24Clock ? 'HH:mm:ss' : 'hh:mm A');
+
 export const timeDayMonYear = (ts: number, dateFormatString: string): string =>
   dayjs(ts).format(dateFormatString);
 


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
This simple PR makes hovering over a message's time show the full time and date of when it was sent, which helps track messages across time, especially when you are searching or moving around to find some specific messages. This feature is the most useful for compact view users.

It follows the date format set up by the user (Settings → General → Date & Time → Date Format)

Screenshots of how it looks:
<img width="554" height="479" alt="Screenshot 2026-03-01 at 22 18 31" src="https://github.com/user-attachments/assets/712c058a-1a80-42c2-95a0-21185d90b184" />
<img width="561" height="481" alt="Screenshot 2026-03-01 at 22 19 57" src="https://github.com/user-attachments/assets/3e24d219-b068-4301-a59f-107c3e73efb7" />

Fixes #2699

#### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
