### PR TITLE
feat: add YYYY-MM-DD (ISO 8601) date format to presets

### DIFF
--- a/src/app/hooks/useDateFormat.ts
+++ b/src/app/hooks/useDateFormat.ts
@@ -26,6 +26,10 @@ export const useDateFormatItems = (): DateFormatItem[] =>
         name: 'YYYY/MM/DD',
       },
       {
+        format: 'YYYY-MM-DD',
+        name: 'YYYY-MM-DD',
+      },
+      {
         format: '',
         name: 'Custom',
       },

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -1,7 +1,7 @@
 import { atom } from 'jotai';
 
 const STORAGE_KEY = 'settings';
-export type DateFormat = 'D MMM YYYY' | 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY/MM/DD' | '';
+export type DateFormat = 'D MMM YYYY' | 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY/MM/DD' | 'YYYY-MM-DD' | '';
 export type MessageSpacing = '0' | '100' | '200' | '300' | '400' | '500';
 export enum MessageLayout {
   Modern = 0,

--- a/src/app/state/settings.ts
+++ b/src/app/state/settings.ts
@@ -1,7 +1,13 @@
 import { atom } from 'jotai';
 
 const STORAGE_KEY = 'settings';
-export type DateFormat = 'D MMM YYYY' | 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY/MM/DD' | 'YYYY-MM-DD' | '';
+export type DateFormat =
+  | 'D MMM YYYY'
+  | 'DD/MM/YYYY'
+  | 'MM/DD/YYYY'
+  | 'YYYY/MM/DD'
+  | 'YYYY-MM-DD'
+  | '';
 export type MessageSpacing = '0' | '100' | '200' | '300' | '400' | '500';
 export enum MessageLayout {
   Modern = 0,


### PR DESCRIPTION
### Description
The YYYY-MM-DD date format is widely used all around the world, and is the one which is used where I'm from. It was a small annoyance to have to manually add it as a custom format every time I logged out and back in, or if I ever set up a new device. It would just save a few seconds here and there for quite a few people.

The YYYY/MM/DD format already exists in Cinny, and I kept it because it's also used, albeit much rarer.

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
