### PR TITLE
Fix invalid matrix.to event link generation

### DIFF
--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -327,11 +327,9 @@ export const MessageCopyLinkItem = as<
   const mx = useMatrixClient();
 
   const handleCopy = () => {
-    const roomIdOrAlias = getCanonicalAliasOrRoomId(mx, room.roomId);
     const eventId = mEvent.getId();
-    const viaServers = isRoomAlias(roomIdOrAlias) ? undefined : getViaServers(room);
     if (!eventId) return;
-    copyToClipboard(getMatrixToRoomEvent(roomIdOrAlias, eventId, viaServers));
+    copyToClipboard(getMatrixToRoomEvent(room.roomId, eventId, getViaServers(room)));
     onClose?.();
   };
 

--- a/src/app/plugins/matrix-to.ts
+++ b/src/app/plugins/matrix-to.ts
@@ -16,11 +16,11 @@ export const getMatrixToRoom = (roomIdOrAlias: string, viaServers?: string[]): s
 };
 
 export const getMatrixToRoomEvent = (
-  roomIdOrAlias: string,
+  roomId: string,
   eventId: string,
   viaServers?: string[]
 ): string => {
-  let fragment = `${roomIdOrAlias}/${eventId}`;
+  let fragment = `${roomId}/${eventId}`;
 
   if (Array.isArray(viaServers) && viaServers.length > 0) {
     fragment = withViaServers(fragment, viaServers);


### PR DESCRIPTION
### Description
alias + event id is not valid in a matrix.to link or matrix: URI https://spec.matrix.org/v1.17/appendices/#matrixto-navigation

Fixes #

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
