### PR TITLE
Fix emojis showing title instead of popup shortcode

### DIFF
--- a/src/app/plugins/react-custom-html-parser.tsx
+++ b/src/app/plugins/react-custom-html-parser.tsx
@@ -16,7 +16,20 @@ import {
 } from 'html-react-parser';
 import { MatrixClient } from 'matrix-js-sdk';
 import classNames from 'classnames';
-import { Box, Chip, config, Header, Icon, IconButton, Icons, Scroll, Text, toRem } from 'folds';
+import {
+  Box,
+  Chip,
+  config,
+  Header,
+  Icon,
+  IconButton,
+  Icons,
+  Scroll,
+  Text,
+  Tooltip,
+  TooltipProvider,
+  toRem,
+} from 'folds';
 import { IntermediateRepresentation, Opts as LinkifyOpts, OptFn } from 'linkifyjs';
 import Linkify from 'linkify-react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -169,13 +182,28 @@ export const scaleSystemEmoji = (text: string): (string | JSX.Element)[] =>
   findAndReplace(
     text,
     EMOJI_REG_G,
-    (match, pushIndex) => (
-      <span key={`scaleSystemEmoji-${pushIndex}`} className={css.EmoticonBase}>
-        <span className={css.Emoticon()} title={getShortcodeFor(getHexcodeForEmoji(match[0]))}>
-          {match[0]}
-        </span>
-      </span>
-    ),
+    (match, pushIndex) => {
+      const shortcode = getShortcodeFor(getHexcodeForEmoji(match[0])) ?? 'unknown';
+      return (
+        <TooltipProvider
+          key={`scaleSystemEmoji-${pushIndex}`}
+          position="Top"
+          tooltip={
+            <Tooltip style={{ maxWidth: toRem(200) }}>
+              <Text size="T300">:{shortcode}:</Text>
+            </Tooltip>
+          }
+        >
+          {(targetRef) => (
+            <span className={css.EmoticonBase}>
+              <span ref={targetRef} className={css.Emoticon()}>
+                {match[0]}
+              </span>
+            </span>
+          )}
+        </TooltipProvider>
+      );
+    },
     (txt) => txt
   );
 


### PR DESCRIPTION
<!-- Please read https://github.com/ajbura/cinny/blob/dev/CONTRIBUTING.md before submitting your pull request -->

### Description
<!-- Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR replaces the `title` popup with a tooltip for displaying the shortcode of an emoji in messages within a room. This also aligns the behaviour with hovering over a reaction.

Fixes #2652 

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
