### PR TITLE
fix: change emojis & stickers pack selector button to dropdown

### DIFF
--- a/src/app/features/settings/emojis-stickers/GlobalPacks.tsx
+++ b/src/app/features/settings/emojis-stickers/GlobalPacks.tsx
@@ -111,14 +111,15 @@ function GlobalPackSelector({
           </Text>
         </Box>
         <Box shrink="No">
-          <Chip
-            radii="Pill"
-            variant={hasSelected ? 'Success' : 'SurfaceVariant'}
-            outlined={hasSelected}
+          <Button
+            size="300"
+            radii="300"
+            variant={hasSelected ? 'Success' : 'Secondary'}
+            fill={hasSelected ? 'Solid' : 'Soft'}
             onClick={() => onSelect(selected)}
           >
             <Text size="B300">{hasSelected ? 'Save' : 'Close'}</Text>
-          </Chip>
+          </Button>
         </Box>
       </Header>
       <Line variant="Surface" size="300" />
@@ -439,6 +440,7 @@ export function GlobalPacks({ onViewPack }: GlobalPacksProps) {
                   size="300"
                   radii="300"
                   outlined
+                  after={<Icon size="300" src={Icons.ChevronBottom} />}
                 >
                   <Text size="B300">Select</Text>
                 </Button>


### PR DESCRIPTION
This PR introduces two changes resolving confusion I had when dealing with Emojis & Stickers Pack selector.

## 1. Changes the button to show down chevron like other dropdowns do.

<img width="167" height="182" alt="image" src="https://github.com/user-attachments/assets/ac0fd81f-61b2-412a-8a77-55abdd6e1694" />

### Before change:

<img width="560" height="106" alt="image" src="https://github.com/user-attachments/assets/e25754d4-cae2-4b9b-999e-6ca62970688e" />

### After change:

<img width="560" height="106" alt="image" src="https://github.com/user-attachments/assets/fb49091e-af92-4433-957e-602c9c3b7dd5" />

## 2. Changes the "Save" button to be a Button component instead of Chip component.

When I initially tried to use this dropdown, I've selected the packs I wanted and did not notice the chip in top right corner changed to green "Save".
I've closed the dropdown by clicking outside and got confused that nothing happened.

A large, solid green "Save" button appearing should help get the user focus to it and suggest saving instead of just closing the dropdown.

### Before change:

<img width="560" height="324" alt="image" src="https://github.com/user-attachments/assets/1fa40678-3400-4f37-a810-fc0cb603a933" />
<img width="560" height="324" alt="image" src="https://github.com/user-attachments/assets/22668bba-303f-4c02-81f3-ba1a558be6bf" />

### After change:

<img width="560" height="324" alt="image" src="https://github.com/user-attachments/assets/c96132b1-5213-484a-9edd-d2b629cee4c3" />
<img width="560" height="324" alt="image" src="https://github.com/user-attachments/assets/6ce26bce-d70a-4684-86ca-575134b68251" />


