### PR TITLE
Move the message context outside of message content

### DIFF
--- a/src/app/components/message/layout/Bubble.tsx
+++ b/src/app/components/message/layout/Bubble.tsx
@@ -30,16 +30,18 @@ type BubbleLayoutProps = {
   hideBubble?: boolean;
   before?: ReactNode;
   header?: ReactNode;
+  context?: ReactNode;
 };
 
 export const BubbleLayout = as<'div', BubbleLayoutProps>(
-  ({ hideBubble, before, header, children, ...props }, ref) => (
+  ({ hideBubble, before, header, context, children, ...props }, ref) => (
     <Box gap="300" {...props} ref={ref}>
       <Box className={css.BubbleBefore} shrink="No">
         {before}
       </Box>
       <Box grow="Yes" direction="Column">
         {header}
+        {context}
         {hideBubble ? (
           children
         ) : (

--- a/src/app/components/message/layout/Compact.tsx
+++ b/src/app/components/message/layout/Compact.tsx
@@ -4,15 +4,22 @@ import * as css from './layout.css';
 
 type CompactLayoutProps = {
   before?: ReactNode;
+  context?: ReactNode;
 };
 
 export const CompactLayout = as<'div', CompactLayoutProps>(
-  ({ before, children, ...props }, ref) => (
-    <Box gap="200" {...props} ref={ref}>
-      <Box className={css.CompactHeader} gap="200" shrink="No">
-        {before}
+  ({ before, context, children, ...props }, ref) => (
+    <Box direction="Column" {...props} ref={ref}>
+      <Box gap="200">
+        <Box className={css.CompactHeader} shrink="No" />
+        {context}
       </Box>
-      {children}
+      <Box gap="200">
+        <Box className={css.CompactHeader} gap="200" shrink="No">
+          {before}
+        </Box>
+        {children}
+      </Box>
     </Box>
   )
 );

--- a/src/app/components/message/layout/Compact.tsx
+++ b/src/app/components/message/layout/Compact.tsx
@@ -10,10 +10,12 @@ type CompactLayoutProps = {
 export const CompactLayout = as<'div', CompactLayoutProps>(
   ({ before, context, children, ...props }, ref) => (
     <Box direction="Column" {...props} ref={ref}>
-      <Box gap="200">
-        <Box className={css.CompactHeader} shrink="No" />
-        {context}
-      </Box>
+      {!!context && (
+        <Box gap="200">
+          <Box className={css.CompactHeader} shrink="No" />
+          {context}
+        </Box>
+      )}
       <Box gap="200">
         <Box className={css.CompactHeader} gap="200" shrink="No">
           {before}

--- a/src/app/components/message/layout/Modern.tsx
+++ b/src/app/components/message/layout/Modern.tsx
@@ -4,15 +4,22 @@ import * as css from './layout.css';
 
 type ModernLayoutProps = {
   before?: ReactNode;
+  context?: ReactNode;
 };
 
-export const ModernLayout = as<'div', ModernLayoutProps>(({ before, children, ...props }, ref) => (
-  <Box gap="300" {...props} ref={ref}>
-    <Box className={css.ModernBefore} shrink="No">
-      {before}
+export const ModernLayout = as<'div', ModernLayoutProps>(({ before, context, children, ...props }, ref) => (
+  <Box direction="Column" {...props} ref={ref}>
+    <Box gap="300">
+      <Box className={css.ModernBefore} shrink="No" />
+      {context}
     </Box>
-    <Box grow="Yes" direction="Column">
-      {children}
+    <Box gap="300">
+      <Box className={css.ModernBefore} shrink="No">
+        {before}
+      </Box>
+      <Box grow="Yes" direction="Column">
+        {children}
+      </Box>
     </Box>
   </Box>
 ));

--- a/src/app/components/message/layout/Modern.tsx
+++ b/src/app/components/message/layout/Modern.tsx
@@ -7,19 +7,23 @@ type ModernLayoutProps = {
   context?: ReactNode;
 };
 
-export const ModernLayout = as<'div', ModernLayoutProps>(({ before, context, children, ...props }, ref) => (
-  <Box direction="Column" {...props} ref={ref}>
-    <Box gap="300">
-      <Box className={css.ModernBefore} shrink="No" />
-      {context}
-    </Box>
-    <Box gap="300">
-      <Box className={css.ModernBefore} shrink="No">
-        {before}
+export const ModernLayout = as<'div', ModernLayoutProps>(
+  ({ before, context, children, ...props }, ref) => (
+    <Box direction="Column" {...props} ref={ref}>
+      {!!context && (
+        <Box gap="300">
+          <Box className={css.ModernBefore} shrink="No" />
+          {context}
+        </Box>
+      )}
+      <Box gap="300">
+        <Box className={css.ModernBefore} shrink="No">
+          {before}
+        </Box>
+        <Box grow="Yes" direction="Column">
+          {children}
+        </Box>
       </Box>
-      <Box grow="Yes" direction="Column">
-        {children}
-      </Box>
     </Box>
-  </Box>
-));
+  )
+);

--- a/src/app/features/room/message/Message.tsx
+++ b/src/app/features/room/message/Message.tsx
@@ -815,7 +815,6 @@ export const Message = as<'div', MessageProps>(
 
     const msgContentJSX = (
       <Box direction="Column" alignSelf="Start" style={{ maxWidth: '100%' }}>
-        {reply}
         {edit && onEditId ? (
           <MessageEditor
             style={{
@@ -1130,17 +1129,17 @@ export const Message = as<'div', MessageProps>(
           </div>
         )}
         {messageLayout === MessageLayout.Compact && (
-          <CompactLayout before={headerJSX} onContextMenu={handleContextMenu}>
+          <CompactLayout before={headerJSX} context={reply} onContextMenu={handleContextMenu}>
             {msgContentJSX}
           </CompactLayout>
         )}
         {messageLayout === MessageLayout.Bubble && (
-          <BubbleLayout before={avatarJSX} header={headerJSX} onContextMenu={handleContextMenu}>
+          <BubbleLayout before={avatarJSX} header={headerJSX} context={reply} onContextMenu={handleContextMenu}>
             {msgContentJSX}
           </BubbleLayout>
         )}
         {messageLayout !== MessageLayout.Compact && messageLayout !== MessageLayout.Bubble && (
-          <ModernLayout before={avatarJSX} onContextMenu={handleContextMenu}>
+          <ModernLayout before={avatarJSX} context={reply} onContextMenu={handleContextMenu}>
             {headerJSX}
             {msgContentJSX}
           </ModernLayout>


### PR DESCRIPTION
This change moves the message context (i.e. reply indicator) outside of actual message content.

### Modern layout

<img width="593" height="80" alt="image" src="https://github.com/user-attachments/assets/f18dd6e8-dc78-422f-9c91-bec054f68309" />

<img width="484" height="85" alt="image" src="https://github.com/user-attachments/assets/f78742db-35f8-4523-87ab-f2fa723a20dc" />

<img width="646" height="134" alt="image" src="https://github.com/user-attachments/assets/983e117a-bd18-486c-9bf8-cd184c3915ea" />

### Bubble layout

<img width="593" height="100" alt="image" src="https://github.com/user-attachments/assets/60354be7-da06-4d19-887e-b9fbba27dffc" />

<img width="568" height="94" alt="image" src="https://github.com/user-attachments/assets/4f9e9ce2-0033-40bc-97fc-b8a5ab05a226" />

<img width="559" height="173" alt="image" src="https://github.com/user-attachments/assets/ede50adb-5d87-470d-8d8a-95cc9e852278" />

### Compact layout

<img width="736" height="63" alt="image" src="https://github.com/user-attachments/assets/5741545d-5444-4122-851b-23d249789692" />

<img width="693" height="58" alt="image" src="https://github.com/user-attachments/assets/7e5a9c47-4c0e-4f0c-a7a1-28aa697c7869" />

<img width="693" height="114" alt="image" src="https://github.com/user-attachments/assets/2a984fdd-50e6-47e1-a629-12fb91730fe5" />
