### PR TITLE
Change play icon and add clickable backdrop on embedded videos.

### DIFF
--- a/src/app/components/message/content/VideoContent.tsx
+++ b/src/app/components/message/content/VideoContent.tsx
@@ -130,17 +130,15 @@ export const VideoContent = as<'div', VideoContentProps>(
           </Box>
         )}
         {!autoPlay && !blurred && srcState.status === AsyncStatus.Idle && (
-          <Box className={css.AbsoluteContainer} alignItems="Center" justifyContent="Center">
-            <Button
-              variant="Secondary"
-              fill="Solid"
-              radii="300"
-              size="300"
-              onClick={loadSrc}
-              before={<Icon size="Inherit" src={Icons.Play} filled />}
-            >
-              <Text size="B300">Watch</Text>
-            </Button>
+          <Box
+            className={css.MediaBackdrop}
+            alignItems="Center"
+            justifyContent="Center"
+            onClick={loadSrc}
+          >
+            <div className={css.WatchButton}>
+              <Icon style={{ width: '100%', height: '100%' }} size="Inherit" src={Icons.Play} filled />
+            </div>
           </Box>
         )}
         {srcState.status === AsyncStatus.Success && (

--- a/src/app/components/message/content/style.css.ts
+++ b/src/app/components/message/content/style.css.ts
@@ -38,3 +38,26 @@ export const Blur = style([
     filter: 'blur(44px)',
   },
 ]);
+
+export const MediaBackdrop = style([
+  AbsoluteContainer,
+  {
+    cursor: 'pointer',
+  },
+]);
+
+export const WatchButton = style({
+  width: '4rem',
+  height: '4rem',
+  color: 'white',
+  opacity: 0.6,
+  transition: 'opacity 0.25s',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  selectors: {
+    [`${MediaBackdrop}:hover &`]: {
+      opacity: 0.8,
+    },
+  },
+});


### PR DESCRIPTION
### Description
This is a small change that just updates the icon displayed over embedded videos to be more minimal, with a slight hover animation, and allows the user to click the entire video embed area to initiate playback instead of just the button itself.

If you would prefer to keep the old button style but still add the backdrop clickable area, I could modify the change to do that. I just felt as though the button didn't really look right.

Comments weren't necessary as this is a very small change.

My reason for making this change is because when I was using Cinny and a friend sent me a video, the first thing I tried to do was just click the video area, and nothing happened. This initially led me to believe I had to download the video to watch it as I didn't notice the "Watch" button initially.


https://github.com/user-attachments/assets/12155754-05d1-4da6-a612-33fadc3f0603

#### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
