### PR TITLE
fix(auth): prevent redundant scrollbar on login page in Firefox

### DIFF
--- a/src/app/pages/auth/AuthLayout.tsx
+++ b/src/app/pages/auth/AuthLayout.tsx
@@ -123,7 +123,13 @@ export function AuthLayout() {
     discoveryState.status === AsyncStatus.Success ? discoveryState.data.response : [];
 
   return (
-    <Scroll variant="Background" visibility="Hover" size="300" hideTrack>
+    <Scroll
+      variant="Background"
+      visibility="Hover"
+      size="300"
+      hideTrack
+      style={{ overflow: 'auto' }}
+    >
       <Box
         className={classNames(css.AuthLayout, PatternsCss.BackgroundDotPattern)}
         direction="Column"


### PR DESCRIPTION
### Description
Fixes a Firefox-specific UI issue where the login/auth screen shows a redundant scrollbar even when content does not overflow.

The auth layout uses the `Scroll` component from `folds`, which can behave as `overflow: scroll` with thin scrollbars. This can cause Firefox to render a visible scrollbar track unnecessarily.
This change sets `overflow: auto` on the auth `Scroll` container so the scrollbar only appears when actual overflow exists.

Fixes #2776

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
