### PR TITLE
fix: room still appearing after leaving it

### DIFF
--- a/src/app/components/leave-room-prompt/LeaveRoomPrompt.tsx
+++ b/src/app/components/leave-room-prompt/LeaveRoomPrompt.tsx
@@ -28,12 +28,11 @@ type LeaveRoomPromptProps = {
 };
 export function LeaveRoomPrompt({ roomId, onDone, onCancel }: LeaveRoomPromptProps) {
   const mx = useMatrixClient();
-  const setRoomsAtom = useSetAtom(allRoomsAtom);
 
   const [leaveState, leaveRoom] = useAsyncCallback<undefined, MatrixError, []>(
     useCallback(async () => {
       mx.leave(roomId);
-      }, [mx, roomId])
+    }, [mx, roomId])
   );
 
   const handleLeave = () => {

--- a/src/app/components/leave-room-prompt/LeaveRoomPrompt.tsx
+++ b/src/app/components/leave-room-prompt/LeaveRoomPrompt.tsx
@@ -20,6 +20,8 @@ import { MatrixError } from 'matrix-js-sdk';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { AsyncStatus, useAsyncCallback } from '../../hooks/useAsyncCallback';
 import { stopPropagation } from '../../utils/keyboard';
+import { useSetAtom } from 'jotai';
+import { allRoomsAtom } from '../../state/room-list/roomList';
 
 type LeaveRoomPromptProps = {
   roomId: string;
@@ -28,11 +30,13 @@ type LeaveRoomPromptProps = {
 };
 export function LeaveRoomPrompt({ roomId, onDone, onCancel }: LeaveRoomPromptProps) {
   const mx = useMatrixClient();
+  const setRoomsAtom = useSetAtom(allRoomsAtom);
 
   const [leaveState, leaveRoom] = useAsyncCallback<undefined, MatrixError, []>(
     useCallback(async () => {
-      mx.leave(roomId);
-    }, [mx, roomId])
+      await mx.leave(roomId);
+      setRoomsAtom({ type: 'DELETE', roomId });
+    }, [mx, roomId, setRoomsAtom])
   );
 
   const handleLeave = () => {

--- a/src/app/components/leave-room-prompt/LeaveRoomPrompt.tsx
+++ b/src/app/components/leave-room-prompt/LeaveRoomPrompt.tsx
@@ -20,8 +20,6 @@ import { MatrixError } from 'matrix-js-sdk';
 import { useMatrixClient } from '../../hooks/useMatrixClient';
 import { AsyncStatus, useAsyncCallback } from '../../hooks/useAsyncCallback';
 import { stopPropagation } from '../../utils/keyboard';
-import { useSetAtom } from 'jotai';
-import { allRoomsAtom } from '../../state/room-list/roomList';
 
 type LeaveRoomPromptProps = {
   roomId: string;
@@ -34,9 +32,8 @@ export function LeaveRoomPrompt({ roomId, onDone, onCancel }: LeaveRoomPromptPro
 
   const [leaveState, leaveRoom] = useAsyncCallback<undefined, MatrixError, []>(
     useCallback(async () => {
-      await mx.leave(roomId);
-      setRoomsAtom({ type: 'DELETE', roomId });
-    }, [mx, roomId, setRoomsAtom])
+      mx.leave(roomId);
+      }, [mx, roomId])
   );
 
   const handleLeave = () => {

--- a/src/app/state/room-list/utils.ts
+++ b/src/app/state/room-list/utils.ts
@@ -37,24 +37,35 @@ export const useBindRoomsWithMembershipsAtom = (
       }
     };
 
-    const handleMembershipChange = (room: Room) => {
-      if (satisfyMembership(room)) {
-        setRoomsAtom({ type: 'PUT', roomId: room.roomId });
+    const handleMembershipEvent = (event: any, _state: any, _room: Room) => {
+      if (event.getType() !== "m.room.member") return;
+      if (event.getStateKey() !== mx.getUserId()) return;
+
+      const membership = event.getContent()?.membership as Membership;
+      const roomId = event.getRoomId(); // so the roomId cannot be undefined
+
+      if (memberships.includes(membership)) {
+        setRoomsAtom({ type: "PUT", roomId });
+        console.log('DEBUG - PUT a room:', roomId);
       } else {
-        setRoomsAtom({ type: 'DELETE', roomId: room.roomId });
+        setRoomsAtom({ type: "DELETE", roomId });
+        console.log('DEBUG - DELETED a room:', roomId);
       }
     };
+
 
     const handleDeleteRoom = (roomId: string) => {
       setRoomsAtom({ type: 'DELETE', roomId });
     };
 
     mx.on(ClientEvent.Room, handleAddRoom);
-    mx.on(RoomEvent.MyMembership, handleMembershipChange);
+    mx.on(RoomEvent.State, handleMembershipEvent);
+    mx.on(RoomEvent.Timeline, handleMembershipEvent);
     mx.on(ClientEvent.DeleteRoom, handleDeleteRoom);
     return () => {
       mx.removeListener(ClientEvent.Room, handleAddRoom);
-      mx.removeListener(RoomEvent.MyMembership, handleMembershipChange);
+      mx.removeListener(RoomEvent.State, handleMembershipEvent);
+      mx.removeListener(RoomEvent.Timeline, handleMembershipEvent);
       mx.removeListener(ClientEvent.DeleteRoom, handleDeleteRoom);
     };
   }, [mx, memberships, setRoomsAtom]);

--- a/src/app/state/room-list/utils.ts
+++ b/src/app/state/room-list/utils.ts
@@ -46,10 +46,8 @@ export const useBindRoomsWithMembershipsAtom = (
 
       if (memberships.includes(membership)) {
         setRoomsAtom({ type: "PUT", roomId });
-        console.log('DEBUG - PUT a room:', roomId);
       } else {
         setRoomsAtom({ type: "DELETE", roomId });
-        console.log('DEBUG - DELETED a room:', roomId);
       }
     };
 

--- a/src/app/state/room-list/utils.ts
+++ b/src/app/state/room-list/utils.ts
@@ -60,7 +60,7 @@ export const useBindRoomsWithMembershipsAtom = (
 
     mx.on(ClientEvent.Room, handleAddRoom);
     mx.on(RoomEvent.State, handleMembershipEvent);
-    mx.on(RoomEvent.Timeline, handleMembershipEvent);
+    mx.on(RoomEvent.Timeline, handleMembershipEvent); // for Redundancy, if RoomEvent.State doesn't fire
     mx.on(ClientEvent.DeleteRoom, handleDeleteRoom);
     return () => {
       mx.removeListener(ClientEvent.Room, handleAddRoom);

--- a/src/app/state/room-list/utils.ts
+++ b/src/app/state/room-list/utils.ts
@@ -38,16 +38,16 @@ export const useBindRoomsWithMembershipsAtom = (
     };
 
     const handleMembershipEvent = (event: any, _state: any, _room: Room) => {
-      if (event.getType() !== "m.room.member") return;
+      if (event.getType() !== 'm.room.member') return;
       if (event.getStateKey() !== mx.getUserId()) return;
 
       const membership = event.getContent()?.membership as Membership;
       const roomId = event.getRoomId(); // so the roomId cannot be undefined
 
       if (memberships.includes(membership)) {
-        setRoomsAtom({ type: "PUT", roomId });
+        setRoomsAtom({ type: 'PUT', roomId });
       } else {
-        setRoomsAtom({ type: "DELETE", roomId });
+        setRoomsAtom({ type: 'DELETE', roomId });
       }
     };
 


### PR DESCRIPTION
Fixes #1623 

Accidentally closed #2851 by renaming the branch

### Description

After leaving a Room, the room would still show up in the room List, only disappearing after a "Cache Clear and Reload". This seems to be because the matrix-js-sdk still caches the old room membership and does not call RoomEvent.MyMembership reliably.

This is sort of a hacky workaround, but it fixes the problem.

I have seen the Notice that you do not accept any new PRs until the SDK has been replaced, so this is in hopes of a quick fix making it through, or atleast of a documented fix for the problem that people can patch their local Cinny deployment with.

Disclaimer: I have used AI assistance to help me find the relevant file to edit, help me troubleshoot and supply the fix.


### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
