### PR TITLE
fix: Removing newlines at start and end of messages

### DIFF
--- a/src/app/components/editor/output.ts
+++ b/src/app/components/editor/output.ts
@@ -187,7 +187,7 @@ export const toPlainText = (node: Descendant | Descendant[], isMarkdown: boolean
 export const customHtmlEqualsPlainText = (customHtml: string, plain: string): boolean =>
   customHtml.replace(/<br\/>/g, '\n') === sanitizeText(plain);
 
-export const trimCustomHtml = (customHtml: string) => customHtml.replace(/<br\/>$/g, '').trim();
+export const trimCustomHtml = (customHtml: string) => customHtml.replace(/^(<br\/>)+|(<br\/>)+$/g, '').trim();
 
 export const trimCommand = (cmdName: string, str: string) => {
   const cmdRegX = new RegExp(`^(\\s+)?(\\/${sanitizeForRegex(cmdName)})([^\\S\n]+)?`);


### PR DESCRIPTION
### Description

Fixes https://github.com/cinnyapp/cinny/issues/2858

**Implementation**

Updates regex-pattern of "trimCustomHtml" to remove all newline-tags at the start and the end of a message before sending. 

**Test results**
- Newlines at the start and end are removed
- It is not possible to add newlines at the start or end through the message editor

**Tested on**
- Chrome
- Firefox